### PR TITLE
Make Deferred API compatible with Py2 code and devappserver

### DIFF
--- a/src/google/appengine/api/app_identity/_metadata_server.py
+++ b/src/google/appengine/api/app_identity/_metadata_server.py
@@ -21,8 +21,6 @@ http://google/third_party/py/google/auth/compute_engine/_metadata.py
 and enhanced to support explicit oauth2 scopes.
 """
 
-
-
 import os
 import time
 from typing import List, Optional, Text, Tuple

--- a/src/google/appengine/ext/deferred/deferred.py
+++ b/src/google/appengine/ext/deferred/deferred.py
@@ -110,6 +110,7 @@ app.wsgi_app = wrap_wsgi_app(app.wsgi_app, use_deferred=True)
 
 import http
 import logging
+import os
 import pickle
 import types
 from google.appengine.api import taskqueue
@@ -264,7 +265,11 @@ def serialize(obj, *args, **kwargs):
     A serialized representation of the callable.
   """
   curried = _curry_callable(obj, *args, **kwargs)
-  return pickle.dumps(curried, protocol=pickle.HIGHEST_PROTOCOL)
+  if os.environ.get("DEFERRED_USE_CROSS_COMPATIBLE_PICKLE_PROTOCOL", False):
+    protocol = 0
+  else:
+    protocol = pickle.HIGHEST_PROTOCOL
+  return pickle.dumps(curried, protocol)
 
 
 def defer(obj, *args, **kwargs):


### PR DESCRIPTION
Make Deferred API compatible with Py2 code and devappserver by introducing an environment variable

Fixes #30, #31

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR