### PR TITLE
base64 encode deferred payloads for better compatibility

### DIFF
--- a/src/google/appengine/ext/deferred/deferred.py
+++ b/src/google/appengine/ext/deferred/deferred.py
@@ -107,7 +107,7 @@ app.wsgi_app = wrap_wsgi_app(app.wsgi_app, use_deferred=True)
 
 
 
-
+import base64
 import http
 import logging
 import os
@@ -159,7 +159,7 @@ def run(data):
     PermanentTaskFailure if an error occurred during unpickling the task.
   """
   try:
-    func, args, kwds = pickle.loads(data)
+    func, args, kwds = pickle.loads(base64.b64decode(data))
   except Exception as e:
     raise PermanentTaskFailure(e)
   else:
@@ -266,10 +266,10 @@ def serialize(obj, *args, **kwargs):
   """
   curried = _curry_callable(obj, *args, **kwargs)
   if os.environ.get("DEFERRED_USE_CROSS_COMPATIBLE_PICKLE_PROTOCOL", False):
-    protocol = 0
+    protocol = 2
   else:
     protocol = pickle.HIGHEST_PROTOCOL
-  return pickle.dumps(curried, protocol)
+  return base64.b64encode(pickle.dumps(curried, protocol))
 
 
 def defer(obj, *args, **kwargs):


### PR DESCRIPTION
One way to fix https://github.com/GoogleCloudPlatform/appengine-python-standard/issues/45

I'm not sure this is exactly the right behavior when it comes to all permutations of compatibility the library wants to main, but I'd be happy to tweak this around (or gate with another env var, or something)