### PR TITLE
ndb.key.urlsafe() should return a string not bytes #71

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, '3.10']
+        python: [3.7, 3.8, 3.9, '3.10', '3.11']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/src/google/appengine/ext/ndb/context.py
+++ b/src/google/appengine/ext/ndb/context.py
@@ -342,7 +342,7 @@ class Context(object):
 
 
 
-  _memcache_prefix = b'NDB9:'
+  _memcache_prefix = 'NDB9:'
 
   @tasklets.tasklet
   def flush(self):

--- a/src/google/appengine/ext/ndb/key.py
+++ b/src/google/appengine/ext/ndb/key.py
@@ -593,7 +593,7 @@ class Key(object):
     """
 
     urlsafe = base64.b64encode(self.reference().SerializeToString())
-    return urlsafe.rstrip(b'=').replace(b'+', b'-').replace(b'/', b'_')
+    return urlsafe.rstrip(b'=').replace(b'+', b'-').replace(b'/', b'_').decode()
 
 
 

--- a/src/google/appengine/ext/ndb/key_test.py
+++ b/src/google/appengine/ext/ndb/key_test.py
@@ -92,7 +92,7 @@ class KeyTests(test_utils.NDBTest):
     e.name = flat[3]
     serialized = r.SerializeToString()
     ref_bytes = six.ensure_binary(r.SerializeToString())
-    urlsafe = base64.urlsafe_b64encode(ref_bytes).rstrip(b'=')
+    urlsafe = base64.urlsafe_b64encode(ref_bytes).rstrip(b'=').decode()
 
     k = key.Key(flat=flat)
     self.assertEqual(k.serialized(), serialized)
@@ -122,7 +122,7 @@ class KeyTests(test_utils.NDBTest):
     self.assertEqual(k.reference(), r)
 
     k1 = key.Key('A', 1)
-    self.assertEqual(k1.urlsafe(), b'ag9uZGItdGVzdC1hcHAtaWRyBwsSAUEYAQw')
+    self.assertEqual(k1.urlsafe(), 'ag9uZGItdGVzdC1hcHAtaWRyBwsSAUEYAQw')
     k2 = key.Key(urlsafe=k1.urlsafe())
     self.assertEqual(k1, k2)
 
@@ -252,7 +252,7 @@ class KeyTests(test_utils.NDBTest):
     r = k.reference()
     serialized = k.serialized()
     urlsafe = k.urlsafe()
-    key.Key(urlsafe=urlsafe.decode('utf8'))
+    key.Key(urlsafe=urlsafe)
     key.Key(serialized=serialized.decode('utf8'))
     key.Key(reference=r)
 

--- a/tests/google/appengine/ext/ndb/key_test.py
+++ b/tests/google/appengine/ext/ndb/key_test.py
@@ -92,7 +92,7 @@ class KeyTests(test_utils.NDBTest):
     e.name = flat[3]
     serialized = r.SerializeToString()
     ref_bytes = six.ensure_binary(r.SerializeToString())
-    urlsafe = base64.urlsafe_b64encode(ref_bytes).rstrip(b'=')
+    urlsafe = base64.urlsafe_b64encode(ref_bytes).rstrip(b'=').decode()
 
     k = key.Key(flat=flat)
     self.assertEqual(k.serialized(), serialized)
@@ -122,7 +122,7 @@ class KeyTests(test_utils.NDBTest):
     self.assertEqual(k.reference(), r)
 
     k1 = key.Key('A', 1)
-    self.assertEqual(k1.urlsafe(), b'ag9uZGItdGVzdC1hcHAtaWRyBwsSAUEYAQw')
+    self.assertEqual(k1.urlsafe(), 'ag9uZGItdGVzdC1hcHAtaWRyBwsSAUEYAQw')
     k2 = key.Key(urlsafe=k1.urlsafe())
     self.assertEqual(k1, k2)
 
@@ -252,7 +252,7 @@ class KeyTests(test_utils.NDBTest):
     r = k.reference()
     serialized = k.serialized()
     urlsafe = k.urlsafe()
-    key.Key(urlsafe=urlsafe.decode('utf8'))
+    key.Key(urlsafe=urlsafe)
     key.Key(serialized=serialized.decode('utf8'))
     key.Key(reference=r)
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 python_files = *_test.py *_unittest.py
 
 [tox]
-envlist = py{37,38,39,310}
+envlist = py{37,38,39,310,311}
 
 [testenv]
 setenv =


### PR DESCRIPTION
Fixes #71 

- [x] Tests pass
