### PR TITLE
Add Python 3.11 Support

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, '3.10']
+        python: [3.7, 3.8, 3.9, '3.10', '3.11']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/src/google/appengine/datastore/datastore_stub_index.py
+++ b/src/google/appengine/datastore/datastore_stub_index.py
@@ -309,7 +309,9 @@ class IndexYamlUpdater(object):
 
 
 
-        fh = openfile(index_yaml_file, 'rU')
+        # The 'U' option is deprecated in py3, as universal newlines
+        # are the default option
+        fh = openfile(index_yaml_file, 'r' if six.PY3 else 'rU')
       except IOError:
         index_yaml_data = None
       else:

--- a/tests/google/appengine/api/mail_stub_unittest.py
+++ b/tests/google/appengine/api/mail_stub_unittest.py
@@ -363,7 +363,7 @@ class MailServiceStubTest(absltest.TestCase):
                stdout=subprocess.PIPE).AndReturn(child)
 
     send.write(
-        mox.Regex(b'^(?s)(?!From ).*' +
+        mox.Regex(b'(?s)^(?!From ).*' +
                   re.escape(b'MIME-Version: 1.0\n'
                             b'To: to@nowhere.com\n'
                             b'Cc: cc1@nowhere.com, cc2@nowhere.com\n'
@@ -456,7 +456,7 @@ class MailServiceStubTest(absltest.TestCase):
                           'cc@nowhere.com',
                           'bcc@nowhere.com'],
 
-                         mox.Regex('^(?s)(?!From ).*' +
+                         mox.Regex('(?s)^(?!From ).*' +
                                    re.escape('MIME-Version: 1.0\n'
                                              'To: to@nowhere.com\n'
                                              'Cc: cc@nowhere.com\n'
@@ -504,7 +504,7 @@ class MailServiceStubTest(absltest.TestCase):
                           'cc@nowhere.com',
                           'bcc@nowhere.com'],
 
-                         mox.Regex('^(?s)(?!From ).*' +
+                         mox.Regex('(?s)^(?!From ).*' +
                                    re.escape('MIME-Version: 1.0\n'
                                              'To: to@nowhere.com\n'
                                              'Cc: cc@nowhere.com\n'

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 python_files = test*.py *_test.py *_unittest.py
 
 [tox]
-envlist = py{37,38,39,310}
+envlist = py{37,38,39,310,311}
 
 [testenv]
 setenv =


### PR DESCRIPTION
This includes the following changes:
- run tests against 3.11
- The `'U'` file open mode is removed in 3.11 ([docs](https://docs.python.org/3/library/functions.html#open)), and its behavior is the default, so we only need to explicilty set it on py2.
- Inline regex flags are now required to be present at the beginning of expressions.

All tests pass on 3.11