### PR TITLE
Support python27 pickle by converting str to bytes.

### DIFF
--- a/src/google/appengine/ext/ndb/model.py
+++ b/src/google/appengine/ext/ndb/model.py
@@ -3043,7 +3043,16 @@ class Model(six.with_metaclass(MetaModel, _NotEqualMixin)):
   def __getstate__(self):
     return self._to_pb().SerializeToString()
 
+  def _py2_compat_encode(self, py2_serialized_pb):
+    return bytes(py2_serialized_pb, 'latin1')
+
   def __setstate__(self, serialized_pb):
+    if isinstance(serialized_pb, str):
+      # If 'serialized_pb' was written by a python27 clone.
+      logging.warning(
+          'Assuming python2 pickled state, converting to python3 type.'
+      )
+      serialized_pb = self._py2_compat_encode(serialized_pb)
     pb = entity_pb2.EntityProto.FromString(serialized_pb)
     self.__init__()
     self.__class__._from_pb(pb, set_key=False, ent=self)


### PR DESCRIPTION
Fixes #70

Add ndb support for compatible py27/py3 memcache entity caching.

Background
Google is strongly encouraging our customers to migrate python27 apps to python3 with bundled services. We envision that during the migration the customer will run with a mix of python27 and python3 clones. Unfortunately this does not work well for apps using ndb because ndb caches datastore entities/ndb/model.Model objects in memcache and objects cached by a clone running python3x cannot read objects cached by python27 or vice versa.

The incompatibility relates to ndb's use of pickle to serialize and unserialize the cached objects.

Known issues

python3 defaults to pickle serial format that is not supported by python27. The customer can specify that memcache use compatible version of pickle by setting the MEMCACHE_USE_CROSS_COMPATIBLE_PROTOCOL environment variable to "true" in their app.yaml

The Model class implements __setstate__ and __getstate__ methods to store the actual entity data as a serialized proto. In python2 the proto library serializes the proto to a str object. python3 pickle fails converting the python2 str object (a string of bytes) to a python3 str object (a string of Unicode characters). The failure occurs because by default pickle assumes the python3 string contains ascii encoded characters (values 0-128) and the actual data includes values outside this range. Here I am proposing the user work around this issue by using a 'latin1' encoding by installing a custom unpickler (example below) This approach requires users to convert all strings holding Unicode the the unicode type because converting using the latin1 encoding will scramble unicode data. Note that this is a global setting and applies to all memache users. An alternative suggested by the customer is to use a binary encoding which also addresses the issue but at the cost of representing all python27 str objects as binary objects in python3. My instinct is that this will be unacceptable for many users.

For python3 the proto function entity_pb2.EntityProto.FromString(serialized_pb) used by __setstate__ requires a bytes object as input. The cl converts the str object returned by unpickling to a the needed type.

Example custom unpickler


def _unpickle_factory(file):
    return six.moves.cPickle.Unpickler(file, encoding='latin1')

memcache.setup_client(memcache.Client(unpickler=_unpickle_factory))
