### PR TITLE
Add `deferred` to the list of available modules in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Then deploy your app as usual, with `gcloud app deploy`. The following modules a
 - `google.appengine.api.users`
 - `google.appengine.ext.blobstore`
 - `google.appengine.ext.db`
+- `google.appengine.ext.deferred`
 - `google.appengine.ext.gql`
 - `google.appengine.ext.key_range`
 - `google.appengine.ext.ndb`


### PR DESCRIPTION
This PR adds the `google.appengine.ext.deferred` module to the list of available modules in the `README.md` file.

Recently I got confused as I thought the `deferred` module is not available in the SDK but then realized it is present in the package. Therefore, I add it to the list with this PR.

- [x] <s>Tests pass</s>
- [x] Appropriate changes to README are included in PR