### PR TITLE
Update docstring to match the actual class name

### DIFF
--- a/src/google/appengine/ext/deferred/deferred.py
+++ b/src/google/appengine/ext/deferred/deferred.py
@@ -45,7 +45,7 @@ be different).
 
 If your app relies on manipulating the import path, make sure that the function
 you are deferring is defined in a module that can be found without import path
-manipulation. Alternately, you can include deferred.TaskHandler in your own
+manipulation. Alternately, you can include deferred.Handler in your own
 webapp application instead of using the easy-install method detailed below.
 
 When you create a deferred task using deferred.defer, the task is serialized,


### PR DESCRIPTION
The class name mentioned in the `deferred.py` docstring did not match the actual class name - `Handler`. It was probably renamed from `TaskHandler` to `Handler` in the past.

https://github.com/GoogleCloudPlatform/appengine-python-standard/blob/a900a13130eb71d6f2dd67ca2d1573c7559053d9/src/google/appengine/ext/deferred/deferred.py#L313C1-L313C10

- [x] <s>Tests pass</s>
- [x] Appropriate changes to README are included in PR