### PR TITLE
Loading imp module only for python2 versions. Python 3.12 has strictly deprecated this module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 src/appengine_python_standard.egg-info
 .tox
 .DS_Store
+build/*
+appengine_python_standard-*-py*.egg

--- a/src/google/appengine/runtime/default_api_stub.py
+++ b/src/google/appengine/runtime/default_api_stub.py
@@ -21,7 +21,6 @@
 """An APIProxy stub that communicates with VMEngine service bridges."""
 
 from concurrent import futures
-import imp
 import logging
 import os
 import sys
@@ -224,12 +223,14 @@ class DefaultApiRPC(apiproxy_rpc.RPC):
         headers=headers,
         body=body_data)
 
+    is_lock_held = False
 
+    if six.PY2:
+      import imp
+      if imp.lock_held():
+        is_lock_held = True
 
-
-
-
-    if six.PY2 and imp.lock_held():
+    if is_lock_held:
       self.future = futures.Future()
       self.future.set_result(self._SendRequestAndFinish(**request_kwargs))
 


### PR DESCRIPTION
Loading imp module only for python2 versions. Python 3.12 has strictly deprecated this module

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR