### PR TITLE
Bump version to 1.1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="appengine-python-standard",
-    version="1.1.5",
+    version="1.1.6",
     author="Google LLC",
     description="Google App Engine services SDK for Python 3",
     long_description=long_description,


### PR DESCRIPTION
This version includes an update to the NDB package - the `msgprop` module was added to provide back-compatibility with App Engine first generation. 

Additionally, an internal package was added to support this module - `google.appengine._internal.protorpc`.