### PR TITLE
Extend / Fix the "NDB_PY2_UNPICKLE_COMPAT" flag

### DIFF
--- a/src/google/appengine/ext/ndb/model.py
+++ b/src/google/appengine/ext/ndb/model.py
@@ -1913,7 +1913,10 @@ class PickleProperty(BlobProperty):
       return pickle.loads(value)
     except UnicodeDecodeError:
       if int(os.environ.get('NDB_PY2_UNPICKLE_COMPAT', '0')):
-        return pickle.loads(value, encoding='bytes')
+        try:
+          return pickle.loads(value, encoding='bytes')
+        except:
+          return pickle.loads(value, encoding='latin1')
       raise
 
 


### PR DESCRIPTION
'latin1' encoding is the fix to most common fix of the DecodeError's, throughout the docs it's the adopted fix as well, which can be seen here: https://cloud.google.com/appengine/docs/standard/python3/services/access

After this fix, I believe the "NDB_PY2_UNPICKLE_COMPAT" flag should be added to the official docs as well

Fixes #111

