### PR TITLE
Updated version constraints for Pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     pyasn1-modules
     pymox < 1.2
     pytest-cov
+    pytest<8
     requests-mock
     rsa
     sortedcontainers


### PR DESCRIPTION
Added version constraints for Pytest (<8). Pytest 8 was causing some of our unit tests to fail.