### PR TITLE
Adding admin API implementation for modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         "six>=1.15.0",
         "urllib3>=1.26.2,<2",
         "legacy-cgi>=2.6.2; python_version>='3.10'",
+        "google-api-python-client"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="appengine-python-standard",
-    version="1.1.10",
+    version="1.3.0-beta",
     author="Google LLC",
     description="Google App Engine services SDK for Python 3",
     long_description=long_description,

--- a/src/google/appengine/api/modules/modules.py
+++ b/src/google/appengine/api/modules/modules.py
@@ -84,7 +84,7 @@ class TransientError(Error):
   """A transient error was encountered, retry the operation."""
 
 def _has_opted_in():
-  return (os.environ.get('MODULES_USE_ADMIN_API', 'false').lower() == 'true')
+  return (os.environ.get('APPENGINE_MODULES_USE_ADMIN_API', 'false').lower() == 'true')
 
 def _raise_error(e):
   # Translate HTTP errors to the exceptions expected by the API

--- a/src/google/appengine/api/modules/modules.py
+++ b/src/google/appengine/api/modules/modules.py
@@ -294,7 +294,7 @@ def get_versions(module=None):
     response = request.execute()
   except errors.HttpError as e:
     if e.resp.status == 404:
-      raise InvalidModuleError(f"Module '{module}' not found.") from e
+      raise InvalidModuleError(f"") from e
     _raise_error(e)
 
   return [version['id'] for version in response.get('versions', [])]
@@ -348,7 +348,7 @@ def get_default_version(module=None):
     response = request.execute()
   except errors.HttpError as e:
     if e.resp.status == 404:
-        raise InvalidModuleError(f"Module '{module}' not found.") from e
+        raise InvalidModuleError(f"") from e
     _raise_error(e)
 
   allocations = response.get('split', {}).get('allocations')
@@ -430,12 +430,15 @@ def get_num_instances(
   try:
     response = request.execute()
   except errors.HttpError as e:
+    if e.resp.status == 404:
+        raise InvalidModuleError(f"") from e
     _raise_error(e)
 
-  if 'manualScaling' in response:
-      return response['manualScaling'].get('instances')
+  if 'manualScaling' not in response:
+      raise InvalidVersionError(f"")
+  
+  return response['manualScaling'].get('instances')
 
-  return 0
   
 def get_num_instances_legacy(module, version):
   def _ResultHook(rpc):
@@ -753,6 +756,8 @@ def get_hostname(
   except errors.HttpError as e:
     _raise_error(e)
 
+  if req_module not in services:
+    raise InvalidModuleError(f"")
   # Legacy Applications (Without "Engines")
   if len(services) == 1 and services[0] == 'default':
     if req_module != 'default':
@@ -832,4 +837,3 @@ def get_hostname_legacy(module, version, instance):
   response = modules_service_pb2.GetHostnameResponse()
   return _MakeAsyncCall('GetHostname', request, response,
                         _ResultHook).get_result()
-

--- a/tests/google/appengine/api/modules/modules_test.py
+++ b/tests/google/appengine/api/modules/modules_test.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,9 +25,13 @@ from google.appengine.api.modules import modules
 from google.appengine.api.modules import modules_service_pb2
 from google.appengine.runtime import apiproxy_errors
 from google.appengine.runtime.context import ctx_test_util
+import google.auth
+import google_auth_httplib2
+from googleapiclient import discovery
 import mox
 
 from absl.testing import absltest
+from googleapiclient import errors
 
 
 @ctx_test_util.isolated_context()
@@ -36,66 +40,84 @@ class ModulesTest(absltest.TestCase):
   def setUp(self):
     """Setup testing environment."""
     self.mox = mox.Mox()
+    self.mock_admin_api_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, 'discovery')
+
+    # Environment variables are cleared in tearDown
+    os.environ['GAE_APPLICATION'] = 's~project'
+    os.environ['GOOGLE_CLOUD_PROJECT'] = 'project'
+    os.environ['GAE_SERVICE'] = 'default'
+    os.environ['GAE_VERSION'] = 'v1'
+    os.environ['CURRENT_MODULE_ID'] = 'default'
+    os.environ['CURRENT_VERSION_ID'] = 'v1.123'
 
   def tearDown(self):
     """Tear down testing environment."""
-    self.mox.VerifyAll()
     self.mox.UnsetStubs()
+    self.mox.VerifyAll()
 
-  def testGetCurrentModuleName_DefaultModule(self):
-    """Test get_current_module_name for default engine."""
-    os.environ['CURRENT_MODULE_ID'] = 'default'
-    os.environ['CURRENT_VERSION_ID'] = 'v1.123'
-    self.assertEqual('default', modules.get_current_module_name())
+    # Clear environment variables that were set in tests
+    for var in [
+        'GAE_SERVICE', 'GAE_VERSION', 'CURRENT_MODULE_ID', 'CURRENT_VERSION_ID',
+        'INSTANCE_ID', 'GAE_INSTANCE', 'GOOGLE_CLOUD_PROJECT', 'GAE_APPLICATION'
+    ]:
+      if var in os.environ:
+        del os.environ[var]
 
-  def testGetCurrentModuleName_NonDefaultModule(self):
-    """Test get_current_module_name for a non default engine."""
-    os.environ['CURRENT_MODULE_ID'] = 'module1'
-    os.environ['CURRENT_VERSION_ID'] = 'v1.123'
+  def _SetupAdminApiMocks(self, project='project'):
+    modules.discovery.build('appengine',
+                            'v1').AndReturn(self.mock_admin_api_client)
+
+  def _CreateHttpError(self, status, reason='Error'):
+    resp = self.mox.CreateMockAnything()
+    resp.status = status
+    resp.reason = reason
+    return errors.HttpError(resp, b'')
+
+  # --- Tests for Get/Set Current Module, Version, Instance ---
+
+  def testGetCurrentModuleName(self):
+    os.environ['GAE_SERVICE'] = 'module1'
     self.assertEqual('module1', modules.get_current_module_name())
 
-  def testGetCurrentModuleName_GaeService(self):
-    """Test get_current_module_name from GAE_SERVICE."""
-    os.environ['GAE_SERVICE'] = 'module1'
-    os.environ['GAE_VERSION'] = 'v1'
-    self.assertEqual('module1', modules.get_current_module_name())
+  def testGetCurrentModuleName_Fallback(self):
+    if 'GAE_SERVICE' in os.environ:
+      del os.environ['GAE_SERVICE']
+    os.environ['CURRENT_MODULE_ID'] = 'module2'
+    self.assertEqual('module2', modules.get_current_module_name())
 
-  def testGetCurrentVersionName_DefaultModule(self):
-    """Test get_current_version_name for default engine."""
-    os.environ['CURRENT_VERSION_ID'] = 'v1.123'
-    self.assertEqual('v1', modules.get_current_version_name())
+  def testGetCurrentVersionName(self):
+    os.environ['GAE_VERSION'] = 'v2'
+    self.assertEqual('v2', modules.get_current_version_name())
 
-  def testGetCurrentVersionName_NonDefaultModule(self):
-    """Test get_current_version_name for a non default engine."""
-    os.environ['CURRENT_MODULE_ID'] = 'module1'
-    os.environ['CURRENT_VERSION_ID'] = 'v1.123'
-    self.assertEqual('v1', modules.get_current_version_name())
+  def testGetCurrentVersionName_Fallback(self):
+    if 'GAE_VERSION' in os.environ:
+      del os.environ['GAE_VERSION']
+    os.environ['CURRENT_VERSION_ID'] = 'v3.456'
+    self.assertEqual('v3', modules.get_current_version_name())
 
-  def testGetCurrentVersionName_VersionIdContainsNone(self):
-    """Test get_current_version_name when 'None' is in version id."""
-    os.environ['CURRENT_MODULE_ID'] = 'module1'
-    os.environ['CURRENT_VERSION_ID'] = 'None.123'
-    self.assertEqual(None, modules.get_current_version_name())
-
-  def testGetCurrentVersionName_GaeVersion(self):
-    """Test get_current_module_name from GAE_SERVICE."""
-    os.environ['GAE_SERVICE'] = 'module1'
-    os.environ['GAE_VERSION'] = 'v1'
-    self.assertEqual('v1', modules.get_current_version_name())
-
-  def testGetCurrentInstanceId_Empty(self):
-    """Test get_current_instance_id when none has been set in the environ."""
-    self.assertEqual(None, modules.get_current_instance_id())
+  def testGetCurrentVersionName_None(self):
+    if 'GAE_VERSION' in os.environ:
+      del os.environ['GAE_VERSION']
+    os.environ['CURRENT_VERSION_ID'] = 'None.456'
+    self.assertIsNone(modules.get_current_version_name())
 
   def testGetCurrentInstanceId(self):
-    """Test get_current_instance_id."""
-    os.environ['INSTANCE_ID'] = '123'
-    self.assertEqual('123', modules.get_current_instance_id())
+    os.environ['GAE_INSTANCE'] = 'instance1'
+    self.assertEqual('instance1', modules.get_current_instance_id())
 
-  def testGetCurrentInstanceId_GaeInstance(self):
-    """Test get_current_instance_id."""
-    os.environ['GAE_INSTANCE'] = '123'
-    self.assertEqual('123', modules.get_current_instance_id())
+  def testGetCurrentInstanceId_Fallback(self):
+    if 'GAE_INSTANCE' in os.environ:
+        del os.environ['GAE_INSTANCE']
+    os.environ['INSTANCE_ID'] = 'instance2'
+    self.assertEqual('instance2', modules.get_current_instance_id())
+
+  def testGetCurrentInstanceId_None(self):
+    if 'GAE_INSTANCE' in os.environ:
+      del os.environ['GAE_INSTANCE']
+    if 'INSTANCE_ID' in os.environ:
+      del os.environ['INSTANCE_ID']
+    self.assertIsNone(modules.get_current_instance_id())
 
   def SetSuccessExpectations(self, method, expected_request, service_response):
     rpc = MockRpc(method, expected_request, service_response)
@@ -110,7 +132,49 @@ class ModulesTest(absltest.TestCase):
     modules._GetRpc().AndReturn(rpc)
     self.mox.ReplayAll()
 
+  # --- Tests for updated get_modules ---
+
   def testGetModules(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_modules').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.list(appsId='project').AndReturn(mock_request)
+    mock_request.execute().AndReturn(
+        {'services': [{'id': 'module1'}, {'id': 'default'}]})
+    self.mox.ReplayAll()
+    self.assertEqual(['module1', 'default'], modules.get_modules())
+
+  def testGetModules_InvalidProject(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_modules').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.list(appsId='project').AndReturn(mock_request)
+    mock_request.execute().AndRaise(self._CreateHttpError(404))
+    self.mox.ReplayAll()
+    with self.assertRaisesRegex(modules.Error, "Project 'project' not found."):
+      modules.get_modules()
+
+  # --- Tests for legacy get_modules ---
+
+  def testGetModulesLegacy(self):
     """Test we return the expected results."""
     service_response = modules_service_pb2.GetModulesResponse()
     service_response.module.append('module1')
@@ -120,7 +184,55 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual(['module1', 'module2'], modules.get_modules())
 
+  # --- Tests for updated get_versions ---
+
   def testGetVersions(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_versions').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.list(
+        appsId='project', servicesId='default', view='FULL').AndReturn(
+            mock_request)
+    mock_request.execute().AndReturn({'versions': [{'id': 'v1'}, {'id': 'v2'}]})
+    self.mox.ReplayAll()
+    self.assertEqual(['v1', 'v2'], modules.get_versions())
+
+  def testGetVersions_InvalidModule(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_versions').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.list(
+        appsId='project', servicesId='foo', view='FULL').AndReturn(mock_request)
+    mock_request.execute().AndRaise(self._CreateHttpError(404))
+    self.mox.ReplayAll()
+    with self.assertRaisesRegex(modules.InvalidModuleError,
+                                  "Module 'foo' not found."):
+      modules.get_versions(module='foo')
+      
+  # --- Tests for Legacy get_versions ---
+  
+  def testGetVersionsLegacy(self):
     """Test we return the expected results."""
     expected_request = modules_service_pb2.GetVersionsRequest()
     expected_request.module = 'module1'
@@ -132,7 +244,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual(['v1', 'v2'], modules.get_versions('module1'))
 
-  def testGetVersions_NoModule(self):
+  def testGetVersionsLegacy_NoModule(self):
     """Test we return the expected results when no module is passed."""
     expected_request = modules_service_pb2.GetVersionsRequest()
     service_response = modules_service_pb2.GetVersionsResponse()
@@ -143,21 +255,123 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual(['v1', 'v2'], modules.get_versions())
 
-  def testGetVersions_InvalidModuleError(self):
+  def testGetVersionsLegacy_InvalidModuleError(self):
     """Test we raise the right error when the given module is invalid."""
     self.SetExceptionExpectations(
         'GetVersions', modules_service_pb2.GetVersionsRequest(),
         modules_service_pb2.ModulesServiceError.INVALID_MODULE)
     self.assertRaises(modules.InvalidModuleError, modules.get_versions)
 
-  def testGetVersions_TransientError(self):
+  def testGetVersionsLegacy_TransientError(self):
     """Test we raise the right error when a transient error is encountered."""
     self.SetExceptionExpectations(
         'GetVersions', modules_service_pb2.GetVersionsRequest(),
         modules_service_pb2.ModulesServiceError.TRANSIENT_ERROR)
     self.assertRaises(modules.TransientError, modules.get_versions)
 
+  # --- Tests for updated get_default_version ---
+
   def testGetDefaultVersion(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+
+    mock_admin_api_client = self.mox.CreateMockAnything()
+
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent(
+        'get_default_version').AndReturn(mock_admin_api_client)
+
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+
+    mock_admin_api_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.get(appsId='project',
+                      servicesId='default').AndReturn(mock_request)
+    mock_request.execute().AndReturn(
+        {'split': {'allocations': {'v1': 0.5, 'v2': 0.5}}})
+
+    self.mox.ReplayAll()
+
+    # The assertion remains the same
+    self.assertEqual('v1', modules.get_default_version())
+
+  def testGetDefaultVersion_Lexicographical(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_admin_api_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent(
+        'get_default_version').AndReturn(mock_admin_api_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_admin_api_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.get(appsId='project',
+                      servicesId='default').AndReturn(mock_request)
+    mock_request.execute().AndReturn(
+        {'split': {'allocations': {'v2-beta': 0.5, 'v1-stable': 0.5}}})
+    self.mox.ReplayAll()
+    self.assertEqual('v1-stable', modules.get_default_version())
+
+
+  def testGetDefaultVersion_NoDefaultVersion(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_admin_api_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent(
+        'get_default_version').AndReturn(mock_admin_api_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_admin_api_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.get(appsId='project',
+                      servicesId='default').AndReturn(mock_request)
+    mock_request.execute().AndReturn({})
+    self.mox.ReplayAll()
+    with self.assertRaisesRegex(modules.InvalidVersionError,
+                                  'Could not determine default version'):
+      modules.get_default_version()
+
+  def testGetDefaultVersion_InvalidModule(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+
+    mock_admin_api_client = self.mox.CreateMockAnything()
+
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent(
+        'get_default_version').AndReturn(mock_admin_api_client)
+
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+
+    mock_admin_api_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.get(appsId='project',
+                      servicesId='foo').AndReturn(mock_request)
+
+    mock_request.execute().AndRaise(self._CreateHttpError(404))
+
+    self.mox.ReplayAll()
+
+    with self.assertRaisesRegex(modules.InvalidModuleError,
+                                  "Module 'foo' not found."):
+      modules.get_default_version(module='foo')
+      
+  # --- Tests for legacy get_default_version ---
+  
+  def testGetDefaultVersionLegacy(self):
     """Test we return the expected results."""
     expected_request = modules_service_pb2.GetDefaultVersionRequest()
     expected_request.module = 'module1'
@@ -168,7 +382,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual('v1', modules.get_default_version('module1'))
 
-  def testGetDefaultVersion_NoModule(self):
+  def testGetDefaultVersionLegacy_NoModule(self):
     """Test we return the expected results when no module is passed."""
     expected_request = modules_service_pb2.GetDefaultVersionRequest()
     service_response = modules_service_pb2.GetDefaultVersionResponse()
@@ -178,21 +392,99 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual('v1', modules.get_default_version())
 
-  def testGetDefaultVersion_InvalidModuleError(self):
+  def testGetDefaultVersionLegacy_InvalidModuleError(self):
     """Test we raise an error when one is received from the lower API."""
     self.SetExceptionExpectations(
         'GetDefaultVersion', modules_service_pb2.GetDefaultVersionRequest(),
         modules_service_pb2.ModulesServiceError.INVALID_MODULE)
     self.assertRaises(modules.InvalidModuleError, modules.get_default_version)
 
-  def testGetDefaultVersion_InvalidVersionError(self):
+  def testGetDefaultVersionLegacy_InvalidVersionError(self):
     """Test we raise an error when one is received from the lower API."""
     self.SetExceptionExpectations(
         'GetDefaultVersion', modules_service_pb2.GetDefaultVersionRequest(),
         modules_service_pb2.ModulesServiceError.INVALID_VERSION)
     self.assertRaises(modules.InvalidVersionError, modules.get_default_version)
+  
+  # --- Tests for updated get_num_instances ---
 
   def testGetNumInstances(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_num_instances').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.get(appsId='project', servicesId='default',
+                      versionsId='v1').AndReturn(mock_request)
+    mock_request.execute().AndReturn({'manualScaling': {'instances': 5}})
+    self.mox.ReplayAll()
+    self.assertEqual(5, modules.get_num_instances())
+
+  def testGetNumInstances_NoManualScaling(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_num_instances').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.get(appsId='project', servicesId='default',
+                      versionsId='v1').AndReturn(mock_request)
+    mock_request.execute().AndReturn({'automaticScaling': {}})
+    self.mox.ReplayAll()
+    self.assertEqual(0, modules.get_num_instances())
+
+  def testGetNumInstances_InvalidVersion(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_num_instances').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.get(appsId='project', servicesId='default',
+                      versionsId='v-bad').AndReturn(mock_request)
+    mock_request.execute().AndRaise(self._CreateHttpError(404))
+    self.mox.ReplayAll()
+    with self.assertRaises(modules.InvalidVersionError):
+      modules.get_num_instances(version='v-bad')
+
+  # --- Tests for updated get_num_instances ---
+  
+  def testGetNumInstancesLegacy(self):
     """Test we return the expected results."""
     expected_request = modules_service_pb2.GetNumInstancesRequest()
     expected_request.module = 'module1'
@@ -204,7 +496,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual(11, modules.get_num_instances('module1', 'v1'))
 
-  def testGetNumInstances_NoVersion(self):
+  def testGetNumInstancesLegacy_NoVersion(self):
     """Test we return the expected results when no version is passed."""
     expected_request = modules_service_pb2.GetNumInstancesRequest()
     expected_request.module = 'module1'
@@ -215,7 +507,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual(11, modules.get_num_instances('module1'))
 
-  def testGetNumInstances_NoModule(self):
+  def testGetNumInstancesLegacy_NoModule(self):
     """Test we return the expected results when no module is passed."""
     expected_request = modules_service_pb2.GetNumInstancesRequest()
     expected_request.version = 'v1'
@@ -226,7 +518,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual(11, modules.get_num_instances(version='v1'))
 
-  def testGetNumInstances_AllDefaults(self):
+  def testGetNumInstancesLegacy_AllDefaults(self):
     """Test we return the expected results when no args are passed."""
     expected_request = modules_service_pb2.GetNumInstancesRequest()
     service_response = modules_service_pb2.GetNumInstancesResponse()
@@ -236,7 +528,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual(11, modules.get_num_instances())
 
-  def testGetNumInstances_InvalidVersionError(self):
+  def testGetNumInstancesLegacy_InvalidVersionError(self):
     """Test we raise the expected error when the API call fails."""
     expected_request = modules_service_pb2.GetNumInstancesRequest()
     expected_request.module = 'module1'
@@ -245,9 +537,77 @@ class ModulesTest(absltest.TestCase):
         'GetNumInstances', expected_request,
         modules_service_pb2.ModulesServiceError.INVALID_VERSION)
     self.assertRaises(modules.InvalidVersionError,
-                      modules.get_num_instances, 'module1', 'v1')
+                      modules.get_num_instances, 'module1', 'v1')  
+  
+  # --- Tests for updated set_num_instances---
 
   def testSetNumInstances(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('set_num_instances').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v1',
+        updateMask='manualScaling.instances',
+        body={'manualScaling': {'instances': 10}}).AndReturn(mock_request)
+    mock_request.execute()
+    self.mox.ReplayAll()
+    modules.set_num_instances(10)
+
+  def testSetNumInstances_TypeError(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    with self.assertRaises(TypeError):
+      modules.set_num_instances('not-an-int')
+
+  def testSetNumInstances_InvalidInstancesError(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('set_num_instances').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v1',
+        updateMask='manualScaling.instances',
+        body={'manualScaling': {'instances': -1}}).AndReturn(mock_request)
+    mock_request.execute().AndRaise(self._CreateHttpError(400))
+    self.mox.ReplayAll()
+    with self.assertRaises(modules.InvalidInstancesError):
+      modules.set_num_instances(-1)
+      
+  # --- Tests for legacy set_num_instances---
+
+  def testSetNumInstancesLegacy(self):
     """Test we return the expected results."""
     expected_request = modules_service_pb2.SetNumInstancesRequest()
     expected_request.module = 'module1'
@@ -259,7 +619,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     modules.set_num_instances(12, 'module1', 'v1')
 
-  def testSetNumInstances_NoVersion(self):
+  def testSetNumInstancesLegacy_NoVersion(self):
     """Test we return the expected results when no version is passed."""
     expected_request = modules_service_pb2.SetNumInstancesRequest()
     expected_request.module = 'module1'
@@ -270,7 +630,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     modules.set_num_instances(13, 'module1')
 
-  def testSetNumInstances_NoModule(self):
+  def testSetNumInstancesLegacy_NoModule(self):
     """Test we return the expected results when no module is passed."""
     expected_request = modules_service_pb2.SetNumInstancesRequest()
     expected_request.version = 'v1'
@@ -281,7 +641,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     modules.set_num_instances(14, version='v1')
 
-  def testSetNumInstances_AllDefaults(self):
+  def testSetNumInstancesLegacy_AllDefaults(self):
     """Test we return the expected results when no args are passed."""
     expected_request = modules_service_pb2.SetNumInstancesRequest()
     expected_request.instances = 15
@@ -291,11 +651,11 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     modules.set_num_instances(15)
 
-  def testSetNumInstances_BadInstancesType(self):
+  def testSetNumInstancesLegacy_BadInstancesType(self):
     """Test we raise an error when we receive a bad instances type."""
     self.assertRaises(TypeError, modules.set_num_instances, 'no good')
 
-  def testSetNumInstances_InvalidVersionError(self):
+  def testSetNumInstancesLegacy_InvalidVersionError(self):
     """Test we raise an error when we receive on from the underlying API."""
     expected_request = modules_service_pb2.SetNumInstancesRequest()
     expected_request.instances = 23
@@ -305,7 +665,7 @@ class ModulesTest(absltest.TestCase):
     self.assertRaises(modules.InvalidVersionError,
                       modules.set_num_instances, 23)
 
-  def testSetNumInstances_TransientError(self):
+  def testSetNumInstancesLegacy_TransientError(self):
     """Test we raise an error when we receive on from the underlying API."""
     expected_request = modules_service_pb2.SetNumInstancesRequest()
     expected_request.instances = 23
@@ -314,7 +674,92 @@ class ModulesTest(absltest.TestCase):
         modules_service_pb2.ModulesServiceError.TRANSIENT_ERROR)
     self.assertRaises(modules.TransientError, modules.set_num_instances, 23)
 
+  # --- Tests for updated start_version---
+
   def testStartVersion(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('start_version').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v1',
+        updateMask='servingStatus',
+        body={'servingStatus': 'SERVING'}).AndReturn(mock_request)
+    mock_request.execute()
+    self.mox.ReplayAll()
+    modules.start_version('default', 'v1')
+
+  def testStartVersion_InvalidVersion(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('start_version').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v-bad',
+        updateMask='servingStatus',
+        body={'servingStatus': 'SERVING'}).AndReturn(mock_request)
+    mock_request.execute().AndRaise(self._CreateHttpError(404))
+    self.mox.ReplayAll()
+    with self.assertRaises(modules.InvalidVersionError):
+      modules.start_version('default', 'v-bad')
+
+  def testStartVersionAsync_NoneArgs(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('start_version').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v1',
+        updateMask='servingStatus',
+        body={'servingStatus': 'SERVING'}).AndReturn(mock_request)
+    mock_request.execute()
+    self.mox.ReplayAll()
+    rpc = modules.start_version_async(None, None)
+    rpc.get_result()
+
+  # --- Tests for legacy start_version---
+  
+  def testStartVersionLegacy(self):
     """Test we pass through the expected args."""
     expected_request = modules_service_pb2.StartModuleRequest()
     expected_request.module = 'module1'
@@ -325,7 +770,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     modules.start_version('module1', 'v1')
 
-  def testStartVersion_InvalidVersionError(self):
+  def testStartVersionLegacy_InvalidVersionError(self):
     """Test we raise an error when we receive one from the API."""
     expected_request = modules_service_pb2.StartModuleRequest()
     expected_request.module = 'module1'
@@ -338,7 +783,7 @@ class ModulesTest(absltest.TestCase):
                       'module1',
                       'v1')
 
-  def testStartVersion_UnexpectedStateError(self):
+  def testStartVersionLegacy_UnexpectedStateError(self):
     """Test we don't raise an error if the version is already started."""
     expected_request = modules_service_pb2.StartModuleRequest()
     expected_request.module = 'module1'
@@ -351,7 +796,7 @@ class ModulesTest(absltest.TestCase):
         modules_service_pb2.ModulesServiceError.UNEXPECTED_STATE)
     modules.start_version('module1', 'v1')
 
-  def testStartVersion_TransientError(self):
+  def testStartVersionLegacy_TransientError(self):
     """Test we raise an error when we receive one from the API."""
     expected_request = modules_service_pb2.StartModuleRequest()
     expected_request.module = 'module1'
@@ -363,19 +808,99 @@ class ModulesTest(absltest.TestCase):
                       modules.start_version,
                       'module1',
                       'v1')
+  
+  # --- Tests for updated stop_version---  
 
   def testStopVersion(self):
-    """Test we pass through the expected args."""
-    expected_request = modules_service_pb2.StopModuleRequest()
-    expected_request.module = 'module1'
-    expected_request.version = 'v1'
-    service_response = modules_service_pb2.StopModuleResponse()
-    self.SetSuccessExpectations('StopModule',
-                                expected_request,
-                                service_response)
-    modules.stop_version('module1', 'v1')
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('stop_version').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
 
-  def testStopVersion_NoModule(self):
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v1',
+        updateMask='servingStatus',
+        body={'servingStatus': 'STOPPED'}).AndReturn(mock_request)
+    mock_request.execute()
+    self.mox.ReplayAll()
+    modules.stop_version()
+
+  def testStopVersion_InvalidVersion(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('stop_version').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v-bad',
+        updateMask='servingStatus',
+        body={'servingStatus': 'STOPPED'}).AndReturn(mock_request)
+    mock_request.execute().AndRaise(self._CreateHttpError(404))
+    self.mox.ReplayAll()
+    with self.assertRaises(modules.InvalidVersionError):
+      modules.stop_version(version='v-bad')
+
+  def testStopVersion_TransientError(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('stop_version').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v1',
+        updateMask='servingStatus',
+        body={'servingStatus': 'STOPPED'}).AndReturn(mock_request)
+    mock_request.execute().AndRaise(self._CreateHttpError(500))
+    self.mox.ReplayAll()
+    with self.assertRaises(modules.TransientError):
+      modules.stop_version()
+
+  # --- Tests for legacy stop_version--
+  
+  def testStopVersionLegacy_NoModule(self):
     """Test we pass through the expected args."""
     expected_request = modules_service_pb2.StopModuleRequest()
     expected_request.version = 'v1'
@@ -385,7 +910,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     modules.stop_version(version='v1')
 
-  def testStopVersion_NoVersion(self):
+  def testStopVersionLegacy_NoVersion(self):
     """Test we pass through the expected args."""
     expected_request = modules_service_pb2.StopModuleRequest()
     expected_request.module = 'module1'
@@ -395,7 +920,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     modules.stop_version('module1')
 
-  def testStopVersion_InvalidVersionError(self):
+  def testStopVersionLegacy_InvalidVersionError(self):
     """Test we raise an error when we receive one from the API."""
     expected_request = modules_service_pb2.StopModuleRequest()
     expected_request.module = 'module1'
@@ -408,7 +933,7 @@ class ModulesTest(absltest.TestCase):
                       'module1',
                       'v1')
 
-  def testStopVersion_AlreadyStopped(self):
+  def testStopVersionLegacy_AlreadyStopped(self):
     """Test we don't raise an error if the version is already stopped."""
     expected_request = modules_service_pb2.StopModuleRequest()
     expected_request.module = 'module1'
@@ -421,14 +946,287 @@ class ModulesTest(absltest.TestCase):
         modules_service_pb2.ModulesServiceError.UNEXPECTED_STATE)
     modules.stop_version('module1', 'v1')
 
-  def testStopVersion_TransientError(self):
+  def testStopVersionLegacy_TransientError(self):
     """Test we raise an error when we receive one from the API."""
     self.SetExceptionExpectations(
         'StopModule', modules_service_pb2.StopModuleRequest(),
         modules_service_pb2.ModulesServiceError.TRANSIENT_ERROR)
     self.assertRaises(modules.TransientError, modules.stop_version)
 
-  def testGetHostname(self):
+  def testRaiseError_Generic(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent(mox.IsA(str)).AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+
+    mock_apps = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.patch(
+        appsId='project',
+        servicesId='default',
+        versionsId='v1',
+        updateMask='servingStatus',
+        body={'servingStatus': 'STOPPED'}).AndReturn(mock_request)
+    mock_request.execute().AndRaise(self._CreateHttpError(401)) # Unauthorized
+    self.mox.ReplayAll()
+    with self.assertRaises(modules.Error):
+        modules.stop_version()
+
+   # --- Tests for updated get_hostname ---
+
+  def testGetHostname_WithVersion_NoInstance(self):
+    """Tests the simple case with an explicit module and version."""
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_admin_api_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent(
+        'get_hostname').AndReturn(mock_admin_api_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_modules')
+    modules.get_modules().AndReturn(['default', 'other'])
+    mock_apps = self.mox.CreateMockAnything()
+    mock_get_request = self.mox.CreateMockAnything()
+    mock_admin_api_client.apps().AndReturn(mock_apps)
+    mock_apps.get(appsId='project').AndReturn(mock_get_request)
+    mock_get_request.execute().AndReturn(
+        {'defaultHostname': 'project.appspot.com'})
+    self.mox.ReplayAll()
+    self.assertEqual('v2.foo.project.appspot.com',
+                     modules.get_hostname(module='foo', version='v2'))
+
+  def testGetHostname_Instance_Success(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client_1 = self.mox.CreateMockAnything()
+    mock_client_2 = self.mox.CreateMockAnything()
+
+    # Mock the two main dependencies of get_hostname
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent(
+        'get_hostname').AndReturn(mock_client_1)
+    self.mox.StubOutWithMock(modules.discovery, 'build')
+    modules.discovery.build('appengine', 'v1').AndReturn(mock_client_2)
+
+    # Mock the helper functions
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_modules')
+    modules.get_modules().AndReturn(['default', 'other'])
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+
+    # Set up expectations for the first client call
+    mock_apps_1 = self.mox.CreateMockAnything()
+    mock_get_request = self.mox.CreateMockAnything()
+    mock_client_1.apps().AndReturn(mock_apps_1)
+    mock_apps_1.get(appsId='project').AndReturn(mock_get_request)
+    mock_get_request.execute().AndReturn(
+        {'defaultHostname': 'project.appspot.com'})
+
+    # Set up expectations for the second client call
+    mock_apps_2 = self.mox.CreateMockAnything()
+    mock_services_2 = self.mox.CreateMockAnything()
+    mock_versions_2 = self.mox.CreateMockAnything()
+    mock_version_request = self.mox.CreateMockAnything()
+    mock_client_2.apps().AndReturn(mock_apps_2)
+    mock_apps_2.services().AndReturn(mock_services_2)
+    mock_services_2.versions().AndReturn(mock_versions_2)
+    mock_versions_2.get(
+        appsId='project', servicesId='default', versionsId='v1',
+        view='FULL').AndReturn(mock_version_request)
+    mock_version_request.execute().AndReturn(
+        {'manualScaling': {'instances': 5}})
+
+    self.mox.ReplayAll()
+
+    self.assertEqual('2.v1.default.project.appspot.com',
+                     modules.get_hostname(instance='2'))
+
+
+  def testGetHostname_Instance_NoManualScaling(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client_1 = self.mox.CreateMockAnything()
+    mock_client_2 = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_hostname').AndReturn(mock_client_1)
+    self.mox.StubOutWithMock(modules.discovery, 'build')
+    modules.discovery.build('appengine', 'v1').AndReturn(mock_client_2)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_modules')
+    modules.get_modules().AndReturn(['default', 'other'])
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+    mock_apps_1 = self.mox.CreateMockAnything()
+    mock_get_request = self.mox.CreateMockAnything()
+    mock_client_1.apps().AndReturn(mock_apps_1)
+    mock_apps_1.get(appsId='project').AndReturn(mock_get_request)
+    mock_get_request.execute().AndReturn(
+        {'defaultHostname': 'project.appspot.com'})
+    mock_apps_2 = self.mox.CreateMockAnything()
+    mock_services_2 = self.mox.CreateMockAnything()
+    mock_versions_2 = self.mox.CreateMockAnything()
+    mock_version_request = self.mox.CreateMockAnything()
+    mock_client_2.apps().AndReturn(mock_apps_2)
+    mock_apps_2.services().AndReturn(mock_services_2)
+    mock_services_2.versions().AndReturn(mock_versions_2)
+    mock_versions_2.get(
+        appsId='project', servicesId='default', versionsId='v1',
+        view='FULL').AndReturn(mock_version_request)
+    mock_version_request.execute().AndReturn({'automaticScaling': {}})
+    self.mox.ReplayAll()
+    with self.assertRaisesRegex(
+        modules.InvalidInstancesError,
+        'Instance-specific hostnames are only available for manually scaled '
+        'services.'):
+      modules.get_hostname(instance='1')
+
+  def testGetHostname_Instance_OutOfBounds(self):
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_api_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(google.auth, 'default')
+    google.auth.default().AndReturn((None, 'project'))
+    
+    self.mox.StubOutWithMock(modules.discovery, 'build')
+    modules.discovery.build('appengine', 'v1', http=mox.IsA(object)).AndReturn(mock_api_client)
+    modules.discovery.build('appengine', 'v1').AndReturn(mock_api_client)
+
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_modules')
+    modules.get_modules().AndReturn(['default', 'other'])
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+    mock_apps = self.mox.CreateMockAnything()
+    mock_get_request = self.mox.CreateMockAnything()
+    mock_services = self.mox.CreateMockAnything()
+    mock_versions = self.mox.CreateMockAnything()
+    mock_version_request = self.mox.CreateMockAnything()
+    mock_api_client.apps().AndReturn(mock_apps)
+    mock_apps.get(appsId='project').AndReturn(mock_get_request)
+    mock_get_request.execute().AndReturn(
+        {'defaultHostname': 'project.appspot.com'})
+    mock_api_client.apps().AndReturn(mock_apps)
+    mock_apps.services().AndReturn(mock_services)
+    mock_services.versions().AndReturn(mock_versions)
+    mock_versions.get(
+        appsId='project', servicesId='default', versionsId='v1',
+        view='FULL').AndReturn(mock_version_request)
+    mock_version_request.execute().AndReturn(
+        {'manualScaling': {'instances': 5}})
+    self.mox.ReplayAll()
+    with self.assertRaisesRegex(
+        modules.InvalidInstancesError,
+        'The specified instance does not exist for this module/version.'):
+      modules.get_hostname(instance='5')
+
+  def testGetHostname_Instance_InvalidValue(self):
+    """Tests instance request with an invalid non-integer instance value."""
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    with self.assertRaisesRegex(
+        modules.InvalidInstancesError,
+        'Instance must be a non-negative integer.'):
+      modules.get_hostname(instance='foo')
+
+  def testGetHostname_NoVersion_VersionExistsOnTarget(self):
+    """Tests no-version call where the current version exists on the target."""
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_hostname').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_modules')
+    modules.get_modules().AndReturn(['default', 'module1'])
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+    self.mox.StubOutWithMock(modules, 'get_versions')
+    modules.get_versions(module='module1').AndReturn(['v1', 'v2'])
+    mock_apps = self.mox.CreateMockAnything()
+    mock_get_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.get(appsId='project').AndReturn(mock_get_request)
+    mock_get_request.execute().AndReturn(
+        {'defaultHostname': 'project.appspot.com'})
+    self.mox.ReplayAll()
+    self.assertEqual('v1.module1.project.appspot.com',
+                     modules.get_hostname(module='module1'))
+
+  def testGetHostname_NoVersion_VersionDoesNotExistOnTarget(self):
+    """Tests no-version call where the current version is not on the target."""
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_hostname').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_modules')
+    modules.get_modules().AndReturn(['default', 'module1'])
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+    self.mox.StubOutWithMock(modules, 'get_versions')
+    modules.get_versions(module='module1').AndReturn(['v2', 'v3'])
+    mock_apps = self.mox.CreateMockAnything()
+    mock_get_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.get(appsId='project').AndReturn(mock_get_request)
+    mock_get_request.execute().AndReturn(
+        {'defaultHostname': 'project.appspot.com'})
+    self.mox.ReplayAll()
+    self.assertEqual('module1.project.appspot.com',
+                     modules.get_hostname(module='module1'))
+
+  def testGetHostname_LegacyApp_Success(self):
+    """Tests a hostname request for a legacy app without engines."""
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    mock_client = self.mox.CreateMockAnything()
+    self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
+    modules._get_admin_api_client_with_useragent('get_hostname').AndReturn(mock_client)
+    self.mox.StubOutWithMock(modules, '_get_project_id')
+    modules._get_project_id().AndReturn('project')
+    self.mox.StubOutWithMock(modules, 'get_modules')
+    modules.get_modules().AndReturn(['default'])
+    self.mox.StubOutWithMock(modules, 'get_current_module_name')
+    modules.get_current_module_name().AndReturn('default')
+    self.mox.StubOutWithMock(modules, 'get_current_version_name')
+    modules.get_current_version_name().AndReturn('v1')
+    mock_apps = self.mox.CreateMockAnything()
+    mock_get_request = self.mox.CreateMockAnything()
+    mock_client.apps().AndReturn(mock_apps)
+    mock_apps.get(appsId='project').AndReturn(mock_get_request)
+    mock_get_request.execute().AndReturn(
+        {'defaultHostname': 'project.appspot.com'})
+    self.mox.ReplayAll()
+    self.assertEqual('v1.project.appspot.com', modules.get_hostname())
+
+  def testGetHostname_LegacyApp_WithInstance(self):
+    """Tests a legacy app request with an invalid non-integer instance."""
+    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    with self.assertRaisesRegex(
+        modules.InvalidInstancesError,
+        'Instance must be a non-negative integer.'):
+      modules.get_hostname(instance='i')
+      
+   # --- Tests for Legacy get_hostname ---
+
+  def testGetHostnameLegacy(self):
     """Test we pass through the expected args."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     expected_request.module = 'module1'
@@ -441,7 +1239,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual('abc', modules.get_hostname('module1', 'v1', '3'))
 
-  def testGetHostname_NoModule(self):
+  def testGetHostnameLegacy_NoModule(self):
     """Test we pass through the expected args when no module is specified."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     expected_request.version = 'v1'
@@ -453,7 +1251,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual('abc', modules.get_hostname(version='v1', instance='3'))
 
-  def testGetHostname_NoVersion(self):
+  def testGetHostnameLegacy_NoVersion(self):
     """Test we pass through the expected args when no version is specified."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     expected_request.module = 'module1'
@@ -466,7 +1264,7 @@ class ModulesTest(absltest.TestCase):
     self.assertEqual('abc',
                      modules.get_hostname(module='module1', instance='3'))
 
-  def testGetHostname_IntInstance(self):
+  def testGetHostnameLegacy_IntInstance(self):
     """Test we pass through the expected args when an int instance is given."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     expected_request.module = 'module1'
@@ -478,7 +1276,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual('abc', modules.get_hostname(module='module1', instance=3))
 
-  def testGetHostname_InstanceZero(self):
+  def testGetHostnameLegacy_InstanceZero(self):
     """Test we pass through the expected args when instance zero is given."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     expected_request.module = 'module1'
@@ -490,7 +1288,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual('abc', modules.get_hostname(module='module1', instance=0))
 
-  def testGetHostname_NoArgs(self):
+  def testGetHostnameLegacy_NoArgs(self):
     """Test we pass through the expected args when none are given."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     service_response = modules_service_pb2.GetHostnameResponse()
@@ -500,7 +1298,7 @@ class ModulesTest(absltest.TestCase):
                                 service_response)
     self.assertEqual('abc', modules.get_hostname())
 
-  def testGetHostname_BadInstanceType(self):
+  def testGetHostnameLegacy_BadInstanceType(self):
     """Test get_hostname throws a TypeError when passed a float for instance."""
     self.assertRaises(TypeError,
                       modules.get_hostname,
@@ -508,7 +1306,7 @@ class ModulesTest(absltest.TestCase):
                       'v1',
                       1.2)
 
-  def testGetHostname_InvalidModuleError(self):
+  def testGetHostnameLegacy_InvalidModuleError(self):
     """Test we raise an error when we receive one from the API."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     expected_request.module = 'module1'
@@ -521,14 +1319,14 @@ class ModulesTest(absltest.TestCase):
                       'module1',
                       'v1')
 
-  def testGetHostname_InvalidInstancesError(self):
+  def testGetHostnameLegacy_InvalidInstancesError(self):
     """Test we raise an error when we receive one from the API."""
     self.SetExceptionExpectations(
         'GetHostname', modules_service_pb2.GetHostnameRequest(),
         modules_service_pb2.ModulesServiceError.INVALID_INSTANCES)
     self.assertRaises(modules.InvalidInstancesError, modules.get_hostname)
 
-  def testGetHostname_UnKnownError(self):
+  def testGetHostnameLegacy_UnKnownError(self):
     """Test we raise an error when we receive one from the API."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     expected_request.module = 'module1'
@@ -541,7 +1339,7 @@ class ModulesTest(absltest.TestCase):
                            'module1',
                            'v1')
 
-  def testGetHostname_UnMappedError(self):
+  def testGetHostnameLegacy_UnMappedError(self):
     """Test we raise an error when we receive one from the API."""
     expected_request = modules_service_pb2.GetHostnameRequest()
     expected_request.module = 'module1'
@@ -556,7 +1354,6 @@ class ModulesTest(absltest.TestCase):
                            modules.get_hostname,
                            'module1',
                            'v1')
-
 
 class MockRpc(object):
   """Mock UserRPC class."""
@@ -594,7 +1391,6 @@ class MockRpc(object):
     self.response = response
     self._hook = get_result_hook
     self.user_data = user_data
-
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/google/appengine/api/modules/modules_test.py
+++ b/tests/google/appengine/api/modules/modules_test.py
@@ -135,7 +135,7 @@ class ModulesTest(absltest.TestCase):
   # --- Tests for updated get_modules ---
 
   def testGetModules(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_modules').AndReturn(mock_client)
@@ -154,7 +154,7 @@ class ModulesTest(absltest.TestCase):
     self.assertEqual(['module1', 'default'], modules.get_modules())
 
   def testGetModules_InvalidProject(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_modules').AndReturn(mock_client)
@@ -187,7 +187,7 @@ class ModulesTest(absltest.TestCase):
   # --- Tests for updated get_versions ---
 
   def testGetVersions(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_versions').AndReturn(mock_client)
@@ -209,7 +209,7 @@ class ModulesTest(absltest.TestCase):
     self.assertEqual(['v1', 'v2'], modules.get_versions())
 
   def testGetVersions_InvalidModule(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_versions').AndReturn(mock_client)
@@ -272,7 +272,7 @@ class ModulesTest(absltest.TestCase):
   # --- Tests for updated get_default_version ---
 
   def testGetDefaultVersion(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
 
     mock_admin_api_client = self.mox.CreateMockAnything()
 
@@ -299,7 +299,7 @@ class ModulesTest(absltest.TestCase):
     self.assertEqual('v1', modules.get_default_version())
 
   def testGetDefaultVersion_Lexicographical(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_admin_api_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent(
@@ -320,7 +320,7 @@ class ModulesTest(absltest.TestCase):
 
 
   def testGetDefaultVersion_NoDefaultVersion(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_admin_api_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent(
@@ -341,7 +341,7 @@ class ModulesTest(absltest.TestCase):
       modules.get_default_version()
 
   def testGetDefaultVersion_InvalidModule(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
 
     mock_admin_api_client = self.mox.CreateMockAnything()
 
@@ -409,7 +409,7 @@ class ModulesTest(absltest.TestCase):
   # --- Tests for updated get_num_instances ---
 
   def testGetNumInstances(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_num_instances').AndReturn(mock_client)
@@ -434,7 +434,7 @@ class ModulesTest(absltest.TestCase):
     self.assertEqual(5, modules.get_num_instances())
 
   def testGetNumInstances_NoManualScaling(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_num_instances').AndReturn(mock_client)
@@ -461,7 +461,7 @@ class ModulesTest(absltest.TestCase):
       modules.get_num_instances()
 
   def testGetNumInstances_InvalidVersion(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_num_instances').AndReturn(mock_client)
@@ -544,7 +544,7 @@ class ModulesTest(absltest.TestCase):
   # --- Tests for updated set_num_instances---
 
   def testSetNumInstances(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('set_num_instances').AndReturn(mock_client)
@@ -573,12 +573,12 @@ class ModulesTest(absltest.TestCase):
     modules.set_num_instances(10)
 
   def testSetNumInstances_TypeError(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     with self.assertRaises(TypeError):
       modules.set_num_instances('not-an-int')
 
   def testSetNumInstances_InvalidInstancesError(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('set_num_instances').AndReturn(mock_client)
@@ -679,7 +679,7 @@ class ModulesTest(absltest.TestCase):
   # --- Tests for updated start_version---
 
   def testStartVersion(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('start_version').AndReturn(mock_client)
@@ -704,7 +704,7 @@ class ModulesTest(absltest.TestCase):
     modules.start_version('default', 'v1')
 
   def testStartVersion_InvalidVersion(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('start_version').AndReturn(mock_client)
@@ -730,7 +730,7 @@ class ModulesTest(absltest.TestCase):
       modules.start_version('default', 'v-bad')
 
   def testStartVersionAsync_NoneArgs(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('start_version').AndReturn(mock_client)
@@ -814,7 +814,7 @@ class ModulesTest(absltest.TestCase):
   # --- Tests for updated stop_version---  
 
   def testStopVersion(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('stop_version').AndReturn(mock_client)
@@ -843,7 +843,7 @@ class ModulesTest(absltest.TestCase):
     modules.stop_version()
 
   def testStopVersion_InvalidVersion(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('stop_version').AndReturn(mock_client)
@@ -871,7 +871,7 @@ class ModulesTest(absltest.TestCase):
       modules.stop_version(version='v-bad')
 
   def testStopVersion_TransientError(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('stop_version').AndReturn(mock_client)
@@ -956,7 +956,7 @@ class ModulesTest(absltest.TestCase):
     self.assertRaises(modules.TransientError, modules.stop_version)
 
   def testRaiseError_Generic(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent(mox.IsA(str)).AndReturn(mock_client)
@@ -989,7 +989,7 @@ class ModulesTest(absltest.TestCase):
 
   def testGetHostname_WithVersion_NoInstance(self):
     """Tests the simple case with an explicit module and version."""
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_admin_api_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent(
@@ -1009,7 +1009,7 @@ class ModulesTest(absltest.TestCase):
                      modules.get_hostname(module='foo', version='v2'))
 
   def testGetHostname_Instance_Success(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client_1 = self.mox.CreateMockAnything()
     mock_client_2 = self.mox.CreateMockAnything()
 
@@ -1055,7 +1055,7 @@ class ModulesTest(absltest.TestCase):
 
 
   def testGetHostname_Instance_NoManualScaling(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client_1 = self.mox.CreateMockAnything()
     mock_client_2 = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
@@ -1095,7 +1095,7 @@ class ModulesTest(absltest.TestCase):
       modules.get_hostname(instance='1')
 
   def testGetHostname_Instance_OutOfBounds(self):
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_api_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(google.auth, 'default')
     google.auth.default().AndReturn((None, 'project'))
@@ -1137,7 +1137,7 @@ class ModulesTest(absltest.TestCase):
 
   def testGetHostname_Instance_InvalidValue(self):
     """Tests instance request with an invalid non-integer instance value."""
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     with self.assertRaisesRegex(
         modules.InvalidInstancesError,
         'Instance must be a non-negative integer.'):
@@ -1145,7 +1145,7 @@ class ModulesTest(absltest.TestCase):
 
   def testGetHostname_NoVersion_VersionExistsOnTarget(self):
     """Tests no-version call where the current version exists on the target."""
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_hostname').AndReturn(mock_client)
@@ -1169,7 +1169,7 @@ class ModulesTest(absltest.TestCase):
 
   def testGetHostname_NoVersion_VersionDoesNotExistOnTarget(self):
     """Tests no-version call where the current version is not on the target."""
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_hostname').AndReturn(mock_client)
@@ -1193,7 +1193,7 @@ class ModulesTest(absltest.TestCase):
 
   def testGetHostname_LegacyApp_Success(self):
     """Tests a hostname request for a legacy app without engines."""
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     mock_client = self.mox.CreateMockAnything()
     self.mox.StubOutWithMock(modules, '_get_admin_api_client_with_useragent')
     modules._get_admin_api_client_with_useragent('get_hostname').AndReturn(mock_client)
@@ -1216,7 +1216,7 @@ class ModulesTest(absltest.TestCase):
 
   def testGetHostname_LegacyApp_WithInstance(self):
     """Tests a legacy app request with an invalid non-integer instance."""
-    os.environ['MODULES_USE_ADMIN_API'] = 'true'
+    os.environ['APPENGINE_MODULES_USE_ADMIN_API'] = 'true'
     with self.assertRaisesRegex(
         modules.InvalidInstancesError,
         'Instance must be a non-negative integer.'):

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,5 @@ deps =
     ruamel.yaml < 0.18
     six
     urllib3
+    google-api-python-client
 commands = pytest --cov=google.appengine {posargs}


### PR DESCRIPTION
Adding admin API implementation for modules API and corresponding tests.
The original implemenation for all modules APIs is as it is and the behavior can be toggled by using the environment variable `MODULES_USE_ADMIN_API` in app.yaml

when `MODULES_USE_ADMIN_API` is set to `true`, admin API implementation will be used.
The original implementation will be used in all other cases

- Tests pass