### PR TITLE
Do not use the deprecated PIL.Image.ANTIALIAS

### DIFF
--- a/src/google/appengine/api/images/images_stub.py
+++ b/src/google/appengine/api/images/images_stub.py
@@ -529,7 +529,7 @@ class ImagesServiceStub(apiproxy_stub.APIProxyStub):
     new_width, new_height = self._CalculateNewDimensions(
         current_width, current_height, width, height, crop_to_fit,
         allow_stretch)
-    new_image = image.resize((new_width, new_height), Image.ANTIALIAS)
+    new_image = image.resize((new_width, new_height), Image.Resampling.LANCZOS)
     if crop_to_fit and (new_width > width or new_height > height):
 
       left = int((new_width - width) * transform.crop_offset_x)


### PR DESCRIPTION
The deprecated Image.ANTIALIAS has been removed in pillow 10, and to run python 3.13 you need at least pillow 11.

Verson compatibility matrix can be found here:
https://pillow.readthedocs.io/en/stable/installation/python-support.html

I don't have python 3.7 any more to test, but pillow 9 already had PIL.Image.Resampling.LANCZOS so should be compatible. Works on python 3.13.