### PR TITLE
feat(taskqueue): Add Cloud Tasks backend and transactional task support for Push Queues using CloudTask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         "six>=1.15.0",
         "urllib3>=1.26.2,<2",
         "legacy-cgi>=2.6.2; python_version>='3.10'",
+        "google-cloud-tasks>=2.24.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/google/appengine/api/__init__.py
+++ b/src/google/appengine/api/__init__.py
@@ -87,6 +87,7 @@ def wrap_wsgi_app(app, use_legacy_context_mode=True, use_deferred=False):
       ]) + [
           middlewares.ErrorLoggingMiddleware,
           middlewares.BackgroundAndShutdownMiddleware,
+          middlewares.CloudTaskSweepMiddleware,
           middlewares.SetNamespaceFromHeader,
       ] + if_deferred_enabled([
           middlewares.AddDeferredMiddleware,

--- a/src/google/appengine/api/taskqueue/cloudtask.py
+++ b/src/google/appengine/api/taskqueue/cloudtask.py
@@ -1,0 +1,498 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud Tasks backend integration for Taskqueue SDK."""
+
+import base64
+from concurrent import futures
+import datetime
+import http
+import json
+import os
+import urllib.error
+import urllib.request
+from google.api_core import exceptions as google_exceptions
+from google.appengine.api import app_identity
+from google.appengine.api.taskqueue import taskqueue
+from google.appengine.api.taskqueue import taskqueue_service_bytes_pb2 as taskqueue_service_pb2
+from google.cloud import tasks_v2beta3
+from google.protobuf import duration_pb2
+from google.protobuf import field_mask_pb2
+from google.protobuf.timestamp_pb2 import Timestamp
+from google.rpc import code_pb2
+
+# Environment variable constants
+ENV_USE_CLOUDTASK_PUSH_QUEUE = 'APPENGINE_USE_CLOUDTASK_PUSH_QUEUE'
+ENV_LOCATION_ID = 'LOCATION_ID'
+ENV_GAE_LOCATION = 'GAE_LOCATION'
+ENV_GAE_REGION = 'GAE_REGION'
+ENV_LOCAL_GCP_REGION = 'LOCAL_GCP_REGION'
+ENV_GOOGLE_CLOUD_PROJECT = 'GOOGLE_CLOUD_PROJECT'
+ENV_GAE_SERVICE = 'GAE_SERVICE'
+ENV_GAE_VERSION = 'GAE_VERSION'
+
+# Sizing & concurrency constants
+_MAX_CONCURRENT_API_CALLS = 100
+_BATCH_CREATE_TASKS_MAX_SIZE = 100
+_BATCH_DELETE_TASKS_MAX_SIZE = 1000
+_METADATA_SERVER_TIMEOUT_SECONDS = 2
+
+_THREAD_POOL = futures.ThreadPoolExecutor(_MAX_CONCURRENT_API_CALLS)
+
+
+# ==============================================================================
+# Public APIs
+# ==============================================================================
+
+
+def is_cloudtask_push_queue_enabled():
+  """Checks if Cloud Tasks backend is enabled for Push Queues."""
+  return str(os.environ.get(ENV_USE_CLOUDTASK_PUSH_QUEUE, '')).lower() == 'true'
+
+
+def create_tasks_in_cloud_tasks(queue_name, tasks, multiple):
+  """Creates one or more tasks using Cloud Tasks API (supporting BatchCreateTasks)."""
+  if len(tasks) == 1:
+    return _create_single_task_in_cloud_tasks(queue_name, tasks[0], multiple)
+  else:
+    return _create_batch_tasks_in_cloud_tasks(queue_name, tasks, multiple)
+
+
+def delete_tasks_in_cloud_tasks(queue_name, tasks, multiple):
+  """Deletes tasks from a queue using Cloud Tasks Client SDK (supporting BatchDeleteTasks)."""
+  client = tasks_v2beta3.CloudTasksClient()
+  project = _get_project_id()
+  region = _get_region()
+
+  parent = client.queue_path(project, region, queue_name)
+
+  # Check pre-conditions (duplicate names or already deleted)
+  task_names_set = set()
+  for task in tasks:
+    if not task.name:
+      raise taskqueue.BadTaskStateError('A task name must be specified for a task')
+    if task.was_deleted:
+      raise taskqueue.BadTaskStateError(
+          'The task %s has already been deleted' % task.name
+      )
+    if task.name in task_names_set:
+      raise taskqueue.DuplicateTaskNameError(
+          'The task name %s is duplicated' % task.name
+      )
+    task_names_set.add(task.name)
+
+  for i in range(0, len(tasks), _BATCH_DELETE_TASKS_MAX_SIZE):
+    batch = tasks[i : i + _BATCH_DELETE_TASKS_MAX_SIZE]
+    task_names = [
+        client.task_path(project, region, queue_name, t.name) for t in batch
+    ]
+
+    try:
+      op = client.batch_delete_tasks(
+          request={'parent': parent, 'names': task_names}
+      )
+      metadata = getattr(op, 'metadata', {})
+      failed_requests = getattr(metadata, 'failed_requests', getattr(metadata, 'failedRequests', {}))
+
+      exception = None
+      for idx, t in enumerate(batch):
+        error_status = failed_requests.get(idx) or failed_requests.get(str(idx))
+        if error_status:
+          code = getattr(error_status, 'code', None)
+          tq_code = _map_rest_code_to_tq_code(code)
+          if tq_code in [taskqueue_service_pb2.TaskQueueServiceError.UNKNOWN_TASK, taskqueue_service_pb2.TaskQueueServiceError.TOMBSTONED_TASK]:
+            t._Task__deleted = False
+          elif exception is None:
+            exception = taskqueue._TranslateError(tq_code)
+        else:
+          t._Task__deleted = True
+
+      if exception is not None:
+        raise exception
+    except Exception as e:
+      raise e
+
+  if multiple:
+    return tasks
+  else:
+    return tasks[0]
+
+
+def purge_queue_in_cloud_tasks(queue_name):
+  """Purges all tasks in a queue using Cloud Tasks API."""
+  client = tasks_v2beta3.CloudTasksClient()
+  project = _get_project_id()
+  region = _get_region()
+
+  name = client.queue_path(project, region, queue_name)
+  try:
+    client.purge_queue(request={'name': name})
+    print(
+        f"Jetski: Successfully purged queue {queue_name} using Cloud Tasks",
+        flush=True,
+    )
+  except Exception as e:
+    raise e
+
+
+def fetch_queue_stats_in_cloud_tasks(queues, multiple):
+  """Fetches queue statistics for given queues using Cloud Tasks API."""
+  client = tasks_v2beta3.CloudTasksClient()
+  project = _get_project_id()
+  region = _get_region()
+
+  queue_stats_list = []
+  read_mask = field_mask_pb2.FieldMask(paths=['stats'])
+
+  for queue in queues:
+    queue_name = queue.name if hasattr(queue, 'name') else str(queue)
+    name = client.queue_path(project, region, queue_name)
+    try:
+      q_resp = client.get_queue(request={'name': name, 'read_mask': read_mask})
+      ct_stats = getattr(q_resp, 'stats', None)
+
+      tasks = getattr(ct_stats, 'tasks_count', 0) if ct_stats else 0
+      oldest_eta_usec = None
+      if ct_stats and getattr(ct_stats, 'oldest_estimated_arrival_time', None):
+        oldest_eta = ct_stats.oldest_estimated_arrival_time
+        oldest_eta_usec = int(oldest_eta.timestamp() * 1e6)
+
+      executed_last_minute = getattr(ct_stats, 'executed_last_minute_count', 0) if ct_stats else 0
+      in_flight = getattr(ct_stats, 'concurrent_dispatches_count', 0) if ct_stats else 0
+      enforced_rate = getattr(ct_stats, 'effective_execution_rate', 0.0) if ct_stats else 0.0
+
+      qs = taskqueue.QueueStatistics(
+          queue=queue,
+          tasks=tasks,
+          oldest_eta_usec=oldest_eta_usec,
+          executed_last_minute=executed_last_minute,
+          in_flight=in_flight,
+          enforced_rate=enforced_rate,
+      )
+      queue_stats_list.append(qs)
+    except google_exceptions.NotFound as e:
+      raise taskqueue.UnknownQueueError(f'Queue {queue_name} not found: {e}')
+    except Exception as e:
+      raise e
+
+  if multiple:
+    return queue_stats_list
+  else:
+    return queue_stats_list[0] if queue_stats_list else None
+
+
+# ==============================================================================
+# Private Helpers
+# ==============================================================================
+
+
+class _CloudTaskRPC(object):
+  """RPC object wrapping asynchronous execution via ThreadPoolExecutor.
+
+  Matches the async model of apiproxy_rpc.py using a ThreadPoolExecutor.
+  Calls are scheduled onto background threads asynchronously, allowing
+  operations to run concurrently until .get_result() or .wait() is called.
+  """
+
+  def __init__(self, future_or_callable):
+    if callable(future_or_callable):
+      self._future = _THREAD_POOL.submit(future_or_callable)
+    else:
+      self._future = future_or_callable
+
+  def get_result(self):
+    return self._future.result()
+
+  def wait(self):
+    self._future.result()
+
+  def check_success(self):
+    self._future.result()
+
+  @property
+  def future(self):
+    return self._future
+
+
+def _get_project_id():
+  """Extracts and formats the Google Cloud project ID."""
+  project = os.environ.get(ENV_GOOGLE_CLOUD_PROJECT)
+  if project and (project.startswith('s~') or project.startswith('e~')):
+    project = project[2:]
+  return project
+
+
+def _get_region():
+  """Determines the App Engine region."""
+  region = (
+      os.environ.get(ENV_LOCATION_ID)
+      or os.environ.get(ENV_GAE_LOCATION)
+      or os.environ.get(ENV_GAE_REGION)
+  )
+  if region:
+    return region
+
+  try:
+    req = urllib.request.Request(
+        'http://metadata.google.internal/computeMetadata/v1/instance/region',
+        headers={'Metadata-Flavor': 'Google'},
+    )
+    with urllib.request.urlopen(req, timeout=_METADATA_SERVER_TIMEOUT_SECONDS) as response:
+      region_path = response.read().decode('utf-8')
+      return region_path.split('/')[-1]
+  except Exception:
+    pass
+
+  # Fallback to us-central1 if we can't detect it
+  return os.environ.get(ENV_LOCAL_GCP_REGION, 'us-central1')
+
+
+def _to_duration(seconds):
+  if seconds is None:
+    return None
+  duration = duration_pb2.Duration()
+  duration.seconds = int(seconds)
+  duration.nanos = int((seconds - duration.seconds) * 1e9)
+  return duration
+
+
+def _build_retry_config(retry_options):
+  if not retry_options:
+    return None
+
+  config = {}
+
+  if retry_options.task_retry_limit is not None:
+    config['max_attempts'] = retry_options.task_retry_limit + 1
+  if retry_options.task_age_limit is not None:
+    config['max_retry_duration'] = _to_duration(retry_options.task_age_limit)
+  if retry_options.min_backoff_seconds is not None:
+    config['min_backoff'] = _to_duration(retry_options.min_backoff_seconds)
+  if retry_options.max_backoff_seconds is not None:
+    config['max_backoff'] = _to_duration(retry_options.max_backoff_seconds)
+  if retry_options.max_doublings is not None:
+    config['max_doublings'] = retry_options.max_doublings
+
+  if config:
+    return config
+  return None
+
+
+def _build_ct_task_payload(queue_name, task, client, project, region):
+  """Builds the Cloud Tasks Task proto payload from GAE Task."""
+  headers = {}
+  if task.headers:
+    headers = dict(task.headers)
+
+  headers['X-AppEngine-QueueName'] = queue_name
+  if task.name:
+    headers['X-AppEngine-TaskName'] = task.name
+
+  body = b''
+  if task.payload:
+    if isinstance(task.payload, str):
+      body = task.payload.encode('utf-8')
+    else:
+      body = task.payload
+
+  http_method = tasks_v2beta3.HttpMethod.POST
+  if task.method:
+    method_map = {
+        'POST': tasks_v2beta3.HttpMethod.POST,
+        'GET': tasks_v2beta3.HttpMethod.GET,
+        'PUT': tasks_v2beta3.HttpMethod.PUT,
+        'DELETE': tasks_v2beta3.HttpMethod.DELETE,
+        'HEAD': tasks_v2beta3.HttpMethod.HEAD,
+    }
+    http_method = method_map.get(task.method, tasks_v2beta3.HttpMethod.POST)
+
+  app_engine_http_request = {
+      'http_method': http_method,
+      'relative_uri': task.url or '/',
+      'body': body,
+      'headers': headers,
+  }
+
+  routing = {}
+  if isinstance(task.target, str) and task.target:
+    target_str = task.target
+    if target_str.endswith('-dot'):
+      target_str = target_str[:-4]
+    target_components = target_str.rsplit('.', 3)
+    target_service = target_components[-1]
+    target_version = len(target_components) > 1 and target_components[-2] or None
+    target_instance = len(target_components) > 2 and target_components[-3] or None
+
+    if target_service:
+      routing['service'] = target_service
+    if target_version:
+      routing['version'] = target_version
+    elif os.environ.get(ENV_GAE_VERSION):
+      routing['version'] = os.environ.get(ENV_GAE_VERSION)
+    if target_instance:
+      routing['instance'] = target_instance
+  else:
+    current_service = os.environ.get(ENV_GAE_SERVICE)
+    if current_service:
+      routing['service'] = current_service
+    current_version = os.environ.get(ENV_GAE_VERSION)
+    if current_version:
+      routing['version'] = current_version
+
+  if routing:
+    app_engine_http_request['app_engine_routing'] = routing
+
+  ct_task = {'app_engine_http_request': app_engine_http_request}
+
+  if task.name:
+    ct_task['name'] = client.task_path(project, region, queue_name, task.name)
+
+  if task.eta:
+    epoch = datetime.datetime.utcfromtimestamp(0)
+    eta = task.eta
+    if eta.tzinfo is not None:
+      eta = eta.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+    delta = eta - epoch
+    seconds = int(delta.total_seconds())
+    nanos = int(delta.microseconds * 1000)
+    timestamp = Timestamp(seconds=seconds, nanos=nanos)
+    ct_task['schedule_time'] = timestamp
+
+  if task.retry_options:
+    retry_config = _build_retry_config(task.retry_options)
+    if retry_config:
+      ct_task['retry_config'] = retry_config
+
+  return ct_task
+
+
+def _create_single_task_in_cloud_tasks(queue_name, task, multiple):
+  """Helper to create a single task using CloudTasksClient CreateTask API."""
+  client = tasks_v2beta3.CloudTasksClient()
+  project = _get_project_id()
+  region = _get_region()
+
+  parent = client.queue_path(project, region, queue_name)
+  ct_task = _build_ct_task_payload(queue_name, task, client, project, region)
+
+  try:
+    response_task = client.create_task(request={'parent': parent, 'task': ct_task})
+    task_id = response_task.name.split('/')[-1]
+    task._Task__name = task_id
+    task._Task__queue_name = queue_name
+    task._Task__enqueued = True
+    if multiple:
+      return [task]
+    else:
+      return task
+  except (google_exceptions.AlreadyExists, google_exceptions.Conflict) as e:
+    raise taskqueue.TaskAlreadyExistsError(str(e))
+  except google_exceptions.NotFound as e:
+    raise taskqueue.UnknownQueueError(str(e))
+  except google_exceptions.BadRequest as e:
+    if 'Queue does not exist' in str(e):
+      raise taskqueue.UnknownQueueError(str(e))
+    raise e
+  except Exception as e:
+    raise e
+
+
+def _create_batch_tasks_in_cloud_tasks(queue_name, tasks, multiple):
+  """Helper to create tasks in batches using CloudTasksClient BatchCreateTasks API."""
+  client = tasks_v2beta3.CloudTasksClient()
+  project = _get_project_id()
+  region = _get_region()
+
+  parent = client.queue_path(project, region, queue_name)
+
+  # Check pre-conditions
+  task_names = set()
+  for task in tasks:
+    if task.name:
+      if task.name in task_names:
+        raise taskqueue.DuplicateTaskNameError(
+            'The task name %s is duplicated' % task.name
+        )
+      task_names.add(task.name)
+
+  created_tasks = []
+  for i in range(0, len(tasks), _BATCH_CREATE_TASKS_MAX_SIZE):
+    batch = tasks[i : i + _BATCH_CREATE_TASKS_MAX_SIZE]
+    requests_payload = []
+    for t in batch:
+      ct_task_payload = _build_ct_task_payload(
+          queue_name, t, client, project, region
+      )
+      requests_payload.append({'parent': parent, 'task': ct_task_payload})
+
+    try:
+      op = client.batch_create_tasks(
+          request={'parent': parent, 'requests': requests_payload}
+      )
+      metadata = getattr(op, 'metadata', {})
+      failed_requests = getattr(metadata, 'failed_requests', getattr(metadata, 'failedRequests', {}))
+      response = getattr(op, 'response', None)
+      response_tasks = getattr(response, 'tasks', []) if response else []
+
+      res_iter = iter(response_tasks)
+      exception = None
+
+      for idx, t in enumerate(batch):
+        error_status = failed_requests.get(idx) or failed_requests.get(str(idx))
+        if error_status:
+          code = getattr(error_status, 'code', None)
+          tq_code = _map_rest_code_to_tq_code(code)
+          if exception is None or isinstance(exception, taskqueue.TaskAlreadyExistsError) or isinstance(exception, taskqueue.TombstonedTaskError):
+            exception = taskqueue._TranslateError(tq_code)
+        else:
+          try:
+            res_task = next(res_iter)
+            task_id = res_task.name.split('/')[-1] if hasattr(res_task, 'name') else res_task['name'].split('/')[-1]
+            t._Task__name = task_id
+            t._Task__queue_name = queue_name
+            t._Task__enqueued = True
+            created_tasks.append(t)
+          except StopIteration:
+            pass
+
+      if exception is not None:
+        raise exception
+    except (google_exceptions.AlreadyExists, google_exceptions.Conflict) as e:
+      raise taskqueue.TaskAlreadyExistsError(str(e))
+    except google_exceptions.NotFound as e:
+      raise taskqueue.UnknownQueueError(str(e))
+    except google_exceptions.BadRequest as e:
+      if 'Queue does not exist' in str(e):
+        raise taskqueue.UnknownQueueError(str(e))
+      raise e
+    except Exception as e:
+      raise e
+
+  if multiple:
+    return created_tasks
+  else:
+    return created_tasks[0]
+
+
+def _map_rest_code_to_tq_code(code):
+  """Maps gRPC / HTTP error status codes to legacy TaskQueue error enum codes."""
+  if code in [code_pb2.NOT_FOUND, http.HTTPStatus.NOT_FOUND]:
+    return taskqueue_service_pb2.TaskQueueServiceError.UNKNOWN_TASK
+  if code in [code_pb2.INVALID_ARGUMENT, http.HTTPStatus.BAD_REQUEST]:
+    return taskqueue_service_pb2.TaskQueueServiceError.INVALID_TASK_NAME
+  if code in [code_pb2.ALREADY_EXISTS, http.HTTPStatus.CONFLICT]:
+    return taskqueue_service_pb2.TaskQueueServiceError.TASK_ALREADY_EXISTS
+  if code in [code_pb2.PERMISSION_DENIED, http.HTTPStatus.FORBIDDEN]:
+    return taskqueue_service_pb2.TaskQueueServiceError.PERMISSION_DENIED
+  return taskqueue_service_pb2.TaskQueueServiceError.INTERNAL_ERROR

--- a/src/google/appengine/api/taskqueue/cloudtask_transactional.py
+++ b/src/google/appengine/api/taskqueue/cloudtask_transactional.py
@@ -1,0 +1,319 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud Tasks transactional task support for Taskqueue SDK."""
+
+import base64
+import contextlib
+import datetime
+import json
+import logging
+import os
+import uuid
+
+from google.api_core import exceptions as google_exceptions
+from google.appengine.api import datastore
+from google.appengine.api.taskqueue import cloudtask
+from google.appengine.api.taskqueue import taskqueue
+from google.cloud import tasks_v2beta3
+from google.protobuf.timestamp_pb2 import Timestamp
+
+try:
+  from google.appengine.ext import ndb
+except ImportError:
+  ndb = None
+
+# Constants
+_PENDING_TASK_KIND = '_AE_PendingCloudTask'
+_TX_TASK_STATUS_PENDING = 'PENDING'
+_TX_TASK_STATUS_PROCESSING = 'PROCESSING'
+_TX_TASK_STATUS_DONE = 'DONE'
+_TX_TASK_STATUS_FAILED = 'FAILED'
+
+_SWEEPER_MAX_RETRIES = 5
+_SWEEPER_LOCK_TIMEOUT_SECONDS = 60
+_SWEEPER_FAST_PATH_GRACE_SECONDS = 60
+
+
+# ==============================================================================
+# Public APIs
+# ==============================================================================
+
+
+def add_transactional_tasks(queue_name, tasks, multiple):
+  """Stages transactional tasks in Datastore within the active transaction."""
+  # Check pre-conditions (duplicate names or already queued)
+  for task in tasks:
+    if task.name:
+      raise taskqueue.InvalidTaskNameError(
+          'A task bound to a transaction cannot be named.'
+      )
+    if task.was_enqueued:
+      raise taskqueue.BadTaskStateError('The task has already been enqueued.')
+
+  pending_keys = []
+  for task in tasks:
+    task_uuid = uuid.uuid4().hex
+    generated_name = f"tx-{task_uuid}"
+    task._Task__name = generated_name
+    task._Task__queue_name = queue_name
+
+    ct_task_payload = build_task_payload_for_transactional_task(
+        queue_name, task
+    )
+
+    # Serialize payload for storage in Datastore
+    st_dict = None
+    if 'schedule_time' in ct_task_payload:
+      st = ct_task_payload['schedule_time']
+      st_dict = {'seconds': getattr(st, 'seconds', 0), 'nanos': getattr(st, 'nanos', 0)}
+
+    ae_req = dict(ct_task_payload['app_engine_http_request'])
+    body_serialized = ae_req.get('body', b'')
+    if isinstance(body_serialized, bytes):
+      body_serialized = base64.b64encode(body_serialized).decode('utf-8')
+    ae_req['body'] = body_serialized
+
+    serializable_payload = {
+        'name': ct_task_payload.get('name'),
+        'app_engine_http_request': ae_req,
+    }
+    if st_dict:
+      serializable_payload['schedule_time'] = st_dict
+    if 'retry_config' in ct_task_payload:
+      serializable_payload['retry_config'] = ct_task_payload['retry_config']
+
+    entity = datastore.Entity(_PENDING_TASK_KIND)
+    entity['task_name'] = generated_name
+    entity['queue_name'] = queue_name
+    entity['payload'] = json.dumps(serializable_payload)
+    entity['status'] = _TX_TASK_STATUS_PENDING
+    entity['created'] = datetime.datetime.utcnow()
+    entity['retry_count'] = 0
+
+    with _use_default_datastore_adapter():
+      datastore.Put(entity)
+    pending_keys.append(entity.key())
+    task._Task__enqueued = True
+
+  _register_post_commit_dispatch(queue_name, pending_keys)
+
+  if multiple:
+    return tasks
+  else:
+    return tasks[0]
+
+
+def build_task_payload_for_transactional_task(queue_name, task):
+  """Builds the Cloud Tasks task payload for a transactional task."""
+  client = tasks_v2beta3.CloudTasksClient()
+  project = cloudtask._get_project_id()
+  region = cloudtask._get_region()
+
+  return cloudtask._build_ct_task_payload(queue_name, task, client, project, region)
+
+
+def dispatch_task_payload(queue_name, task_payload):
+  """Dispatches a pre-built task payload immediately using CloudTasksClient."""
+  client = tasks_v2beta3.CloudTasksClient()
+  project = cloudtask._get_project_id()
+  region = cloudtask._get_region()
+
+  parent = client.queue_path(project, region, queue_name)
+
+  # Prepare task payload for GAPIC client call
+  if 'app_engine_http_request' in task_payload:
+    ae_req = dict(task_payload['app_engine_http_request'])
+    if 'body' in ae_req and isinstance(ae_req['body'], str):
+      ae_req['body'] = base64.b64decode(ae_req['body'].encode('utf-8'))
+    task_payload['app_engine_http_request'] = ae_req
+
+  if 'schedule_time' in task_payload and isinstance(task_payload['schedule_time'], dict):
+    st = task_payload['schedule_time']
+    task_payload['schedule_time'] = Timestamp(seconds=st.get('seconds', 0), nanos=st.get('nanos', 0))
+
+  client.create_task(request={'parent': parent, 'task': task_payload})
+
+
+def sweep():
+  """Queries Datastore for pending Cloud Tasks and dispatches them."""
+  try:
+    with _use_default_datastore_adapter():
+      query = datastore.Query(_PENDING_TASK_KIND)
+      entities = query.Run()
+  except Exception as e:
+    logging.error("Failed to query %s in sweeper: %s", _PENDING_TASK_KIND, e)
+    return
+
+  now = datetime.datetime.utcnow()
+  keys_to_dispatch = []
+  for entity in entities:
+    if not entity:
+      continue
+    status = entity.get('status', _TX_TASK_STATUS_PENDING)
+    if status == _TX_TASK_STATUS_DONE:
+      continue
+    if status == _TX_TASK_STATUS_PROCESSING:
+      lock_expires = entity.get('lock_expires')
+      if lock_expires and isinstance(lock_expires, datetime.datetime):
+        if now < lock_expires:
+          continue  # still actively processing and lock valid
+      elif not lock_expires:
+        continue  # assume lock valid if just started
+
+    created = entity.get('created')
+    if status == _TX_TASK_STATUS_PENDING and created and isinstance(created, datetime.datetime):
+      if (now - created).total_seconds() < _SWEEPER_FAST_PATH_GRACE_SECONDS:
+        continue  # give fast-path grace period to dispatch post-commit
+
+    retry_count = entity.get('retry_count', 0)
+    if status == _TX_TASK_STATUS_FAILED and retry_count >= _SWEEPER_MAX_RETRIES:
+      continue  # exceeded max sweeper retries
+
+    keys_to_dispatch.append(entity.key())
+
+  if keys_to_dispatch:
+    logging.info("Cloud Tasks sweeper found %d tasks to process.", len(keys_to_dispatch))
+    _dispatch_pending_keys_now(keys_to_dispatch, handled_by_sweeper=True)
+
+
+def sweep_wsgi_app(environ, start_response):
+  """WSGI app handler for /_ah/cloudtask/sweep."""
+  is_cron = str(environ.get('HTTP_X_APPENGINE_CRON', '')).lower() == 'true' or str(environ.get('X-AppEngine-Cron', '')).lower() == 'true'
+  if not is_cron and not str(environ.get('SERVER_SOFTWARE', '')).lower().startswith('dev'):
+    status = '403 Forbidden'
+    response_headers = [('Content-Type', 'text/plain')]
+    start_response(status, response_headers)
+    return [b'Access denied: endpoint only accessible via App Engine Cron.\n']
+
+  try:
+    sweep()
+    status = '200 OK'
+    response_headers = [('Content-Type', 'text/plain')]
+    start_response(status, response_headers)
+    return [b'Sweeper completed successfully.\n']
+  except Exception as e:
+    logging.error("Cloud Tasks sweeper failed: %s", e)
+    status = '500 Internal Server Error'
+    response_headers = [('Content-Type', 'text/plain')]
+    start_response(status, response_headers)
+    return [f'Sweeper failed: {e}\n'.encode('utf-8')]
+
+
+# ==============================================================================
+# Private Helpers
+# ==============================================================================
+
+
+@contextlib.contextmanager
+def _use_default_datastore_adapter(non_transactional=False):
+  popped_conn = None
+  if non_transactional and datastore.IsInTransaction():
+    popped_conn = datastore._PopConnection()
+
+  try:
+    conn = datastore._GetConnection()
+    orig_adapter = getattr(conn, '_BaseConnection__adapter', None)
+    if orig_adapter is not None:
+      conn._BaseConnection__adapter = datastore._adapter
+      try:
+        yield
+      finally:
+        conn._BaseConnection__adapter = orig_adapter
+    else:
+      yield
+  finally:
+    if popped_conn is not None:
+      datastore._PushConnection(popped_conn)
+
+
+def _dispatch_pending_keys_now(pending_keys, handled_by_sweeper=False):
+  try:
+    with _use_default_datastore_adapter(non_transactional=True):
+      entities = datastore.Get(pending_keys)
+  except Exception as e:
+    logging.error("Failed to fetch pending transactional tasks: %s", e)
+    return
+
+  if not isinstance(entities, list):
+    entities = [entities]
+
+  for entity in entities:
+    if not entity:
+      continue
+    task_name = entity.get('task_name')
+    queue_name = entity.get('queue_name')
+    payload_str = entity.get('payload')
+
+    # Acquire lock on entity to prevent duplicate sweeper dispatches
+    now = datetime.datetime.utcnow()
+    try:
+      entity['status'] = _TX_TASK_STATUS_PROCESSING
+      entity['lock_expires'] = now + datetime.timedelta(seconds=_SWEEPER_LOCK_TIMEOUT_SECONDS)
+      entity['handled_by_sweeper'] = handled_by_sweeper
+      with _use_default_datastore_adapter(non_transactional=True):
+        datastore.Put(entity)
+    except Exception as e:
+      logging.warning("Failed to acquire lock for task %s: %s", task_name, e)
+      continue
+
+    try:
+      payload = json.loads(payload_str)
+      dispatch_task_payload(queue_name, payload)
+      with _use_default_datastore_adapter(non_transactional=True):
+        datastore.Delete(entity.key())
+      logging.info("Successfully dispatched transactional task %s", task_name)
+    except (google_exceptions.AlreadyExists, google_exceptions.Conflict):
+      with _use_default_datastore_adapter(non_transactional=True):
+        datastore.Delete(entity.key())
+      logging.info("Transactional task %s already exists in Cloud Tasks; cleaned up entity", task_name)
+    except Exception as e:
+      logging.error(
+          "Failed to dispatch transactional task %s: %s", task_name, e
+      )
+      retry_count = entity.get('retry_count', 0) + 1
+      entity['retry_count'] = retry_count
+      entity['last_error'] = str(e)[:500]
+      if retry_count >= _SWEEPER_MAX_RETRIES:
+        entity['status'] = _TX_TASK_STATUS_FAILED
+        entity['lock_expires'] = None
+      else:
+        entity['status'] = _TX_TASK_STATUS_PENDING
+        entity['lock_expires'] = None
+      try:
+        with _use_default_datastore_adapter(non_transactional=True):
+          datastore.Put(entity)
+      except Exception as put_err:
+        logging.error("Failed to record error state for task %s: %s", task_name, put_err)
+
+
+def _register_post_commit_dispatch(queue_name, pending_keys):
+  if ndb and ndb.in_transaction():
+    ndb.get_context().call_on_commit(
+        lambda: _dispatch_pending_keys_now(pending_keys)
+    )
+    return
+
+  if datastore.IsInTransaction():
+    conn = datastore._GetConnection()
+    if not hasattr(conn, '_on_commit_callbacks'):
+      conn._on_commit_callbacks = []
+    conn._on_commit_callbacks.append(
+        lambda: _dispatch_pending_keys_now(pending_keys)
+    )
+    return
+
+  raise taskqueue.BadTransactionStateError(
+      'Transactional tasks must be added inside a transaction.'
+  )

--- a/src/google/appengine/api/taskqueue/taskqueue.py
+++ b/src/google/appengine/api/taskqueue/taskqueue.py
@@ -46,6 +46,8 @@ from google.appengine.api import namespace_manager
 from google.appengine.api import urlfetch
 from google.appengine.api.taskqueue import taskqueue_service_bytes_pb2 as taskqueue_service_pb2
 from google.appengine.runtime import apiproxy_errors
+from google.appengine.api.taskqueue import cloudtask
+from google.appengine.api.taskqueue import cloudtask_transactional
 from google.appengine.runtime import context
 import six
 from six.moves import urllib
@@ -1557,13 +1559,13 @@ class QueueStatistics(object):
 
       return []
 
-    rpc = create_rpc(deadline)
-    cls.fetch_async(queue_or_queues, rpc)
-    return rpc.get_result()
+    return cls.fetch_async(queue_or_queues).get_result()
 
   @classmethod
   def _FetchMultipleQueues(cls, queues, multiple, rpc=None):
     """Internal implementation of fetch stats where queues must be a list."""
+    if cloudtask.is_cloudtask_push_queue_enabled():
+      return cloudtask._CloudTaskRPC(lambda: cloudtask.fetch_queue_stats_in_cloud_tasks(queues, multiple))
 
     def ResultHook(rpc):
       """Processes the TaskQueueFetchQueueStatsResponse."""
@@ -1654,6 +1656,10 @@ class Queue(object):
     Raises:
       Error-subclass on application errors.
     """
+    if cloudtask.is_cloudtask_push_queue_enabled():
+      cloudtask.purge_queue_in_cloud_tasks(self.__name)
+      return
+
     request = taskqueue_service_pb2.TaskQueuePurgeQueueRequest()
     response = taskqueue_service_pb2.TaskQueuePurgeQueueResponse()
 
@@ -1789,6 +1795,9 @@ class Queue(object):
 
   def __DeleteTasks(self, tasks, multiple, rpc=None):
     """Internal implementation of delete_tasks_async(), tasks must be a list."""
+    if (cloudtask.is_cloudtask_push_queue_enabled()
+        and not any(getattr(t, 'method', None) == 'PULL' for t in tasks)):
+      return cloudtask._CloudTaskRPC(lambda: cloudtask.delete_tasks_in_cloud_tasks(self.__name, tasks, multiple))
 
     def ResultHook(rpc):
       """Processes the TaskQueueDeleteResponse."""
@@ -2133,6 +2142,16 @@ class Queue(object):
       raise InvalidTaskError(
           'You cannot add both push and pull tasks in a single call.')
 
+    # Intercept for Cloud Tasks backend
+    if (cloudtask.is_cloudtask_push_queue_enabled()
+        and has_push_task
+        and len(tasks) >= 1):
+      if transactional:
+        cloudtask_transactional.add_transactional_tasks(self.__name, tasks, multiple)
+        return cloudtask._CloudTaskRPC(lambda: tasks if multiple else tasks[0])
+      else:
+        return cloudtask._CloudTaskRPC(lambda: cloudtask.create_tasks_in_cloud_tasks(self.__name, tasks, multiple))
+
     if has_push_task:
       fill_function = self.__FillAddPushTasksRequest
     else:
@@ -2471,9 +2490,7 @@ class Queue(object):
       Error-subclass on application errors.
     """
     _ValidateDeadline(deadline)
-    rpc = create_rpc(deadline)
-    self.fetch_statistics_async(rpc)
-    return rpc.get_result()
+    return self.fetch_statistics_async().get_result()
 
   def __repr__(self):
     ATTRS = ['name']
@@ -2596,3 +2613,5 @@ def add(*args, **kwargs):
   queue_name = kwargs.pop('queue_name', _DEFAULT_QUEUE)
   return Task(*args, **kwargs).add(
       queue_name=queue_name, transactional=transactional)
+
+

--- a/src/google/appengine/datastore/datastore_rpc.py
+++ b/src/google/appengine/datastore/datastore_rpc.py
@@ -2626,6 +2626,13 @@ class TransactionalConnection(BaseConnection):
     transaction = self.transaction
     if transaction is None:
       self._state = TransactionalConnection.CLOSED
+      callbacks = getattr(self, '_on_commit_callbacks', None)
+      if callbacks:
+        for cb in callbacks:
+          try:
+            cb()
+          except Exception as e:
+            logging.error('Error in on_commit callback: %s', e)
       return None
 
     if self._api_version == _CLOUD_DATASTORE_V1:
@@ -2668,6 +2675,13 @@ class TransactionalConnection(BaseConnection):
       else:
         raise _ToDatastoreError(err)
     else:
+      callbacks = getattr(self, '_on_commit_callbacks', None)
+      if callbacks:
+        for cb in callbacks:
+          try:
+            cb()
+          except Exception as e:
+            logging.error('Error in on_commit callback: %s', e)
       return True
 
 

--- a/src/google/appengine/runtime/middlewares.py
+++ b/src/google/appengine/runtime/middlewares.py
@@ -379,6 +379,26 @@ def BackgroundAndShutdownMiddleware(app, wsgi_env, start_response):
 
 
 @middleware
+def CloudTaskSweepMiddleware(app, wsgi_env, start_response):
+  """Intercept calls to the endpoint for Cloud Tasks Transactional Sweeper.
+
+  Handle requests made to /_ah/cloudtask/sweep
+
+  Args:
+    app: the WSGI app to wrap
+    wsgi_env: see PEP 3333
+    start_response: see PEP 3333
+  Returns:
+    The wrapped WSGI app response in UTF-8 format
+  """
+  path = wsgi_env['PATH_INFO']
+  if path == '/_ah/cloudtask/sweep':
+    from google.appengine.api.taskqueue import cloudtask_transactional
+    return cloudtask_transactional.sweep_wsgi_app(wsgi_env, start_response)
+  return app(wsgi_env, start_response)
+
+
+@middleware
 def AddDeferredMiddleware(app, wsgi_env, start_response):
   """Intercept calls to the default endpoint for Deferred.
 

--- a/tests/google/appengine/api/taskqueue/cloudtask_test.py
+++ b/tests/google/appengine/api/taskqueue/cloudtask_test.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import http
+import os
+import time
+import unittest
+from unittest import mock
+from google.appengine.api.taskqueue import cloudtask
+from google.appengine.api.taskqueue import taskqueue
+from google.appengine.api.taskqueue import taskqueue_service_bytes_pb2 as taskqueue_service_pb2
+from google.rpc import code_pb2
+
+
+class CloudtaskTest(unittest.TestCase):
+
+  def setUp(self):
+    super(CloudtaskTest, self).setUp()
+    self.mock_client = mock.Mock()
+    self.mock_client.task_path.return_value = 'projects/p/locations/l/queues/q/tasks/t'
+
+  @mock.patch.dict(os.environ, {'GAE_SERVICE': 'default-service'}, clear=False)
+  @mock.patch('google.appengine.api.app_identity.get_default_version_hostname', return_value='app.appspot.com')
+  def test_build_ct_task_payload_with_default_app_version_target(self, _):
+    task = taskqueue.Task(url='/test', target=taskqueue.DEFAULT_APP_VERSION)
+    payload = cloudtask._build_ct_task_payload(
+        queue_name='default',
+        task=task,
+        client=self.mock_client,
+        project='p',
+        region='us-central1'
+    )
+    self.assertIn('app_engine_http_request', payload)
+    self.assertEqual(
+        payload['app_engine_http_request'].get('app_engine_routing', {}).get('service'),
+        'default-service'
+    )
+
+  @mock.patch.dict(os.environ, {}, clear=True)
+  @mock.patch('google.appengine.api.app_identity.get_default_version_hostname', return_value='app.appspot.com')
+  def test_build_ct_task_payload_with_string_target(self, _):
+    task = taskqueue.Task(url='/test', target='worker-dot')
+    payload = cloudtask._build_ct_task_payload(
+        queue_name='default',
+        task=task,
+        client=self.mock_client,
+        project='p',
+        region='us-central1'
+    )
+    self.assertEqual(
+        payload['app_engine_http_request'].get('app_engine_routing', {}).get('service'),
+        'worker'
+    )
+
+  @mock.patch.dict(os.environ, {}, clear=True)
+  @mock.patch('google.appengine.api.app_identity.get_default_version_hostname', return_value='app.appspot.com')
+  def test_build_ct_task_payload_with_version_service_target(self, _):
+    task = taskqueue.Task(url='/test', target='v2.worker')
+    payload = cloudtask._build_ct_task_payload(
+        queue_name='default',
+        task=task,
+        client=self.mock_client,
+        project='p',
+        region='us-central1'
+    )
+    routing = payload['app_engine_http_request'].get('app_engine_routing', {})
+    self.assertEqual(routing.get('service'), 'worker')
+    self.assertEqual(routing.get('version'), 'v2')
+
+  def test_build_ct_task_payload_with_countdown(self):
+    now = time.time()
+    countdown_seconds = 60
+    task = taskqueue.Task(url='/test', countdown=countdown_seconds)
+    payload = cloudtask._build_ct_task_payload(
+        queue_name='default',
+        task=task,
+        client=self.mock_client,
+        project='p',
+        region='us-central1'
+    )
+    self.assertIn('schedule_time', payload)
+    st = payload['schedule_time']
+    self.assertAlmostEqual(st.seconds, int(now + countdown_seconds), delta=2)
+
+  def test_build_ct_task_payload_with_eta(self):
+    eta = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=120)
+    task = taskqueue.Task(url='/test', eta=eta)
+    payload = cloudtask._build_ct_task_payload(
+        queue_name='default',
+        task=task,
+        client=self.mock_client,
+        project='p',
+        region='us-central1'
+    )
+    self.assertIn('schedule_time', payload)
+    st = payload['schedule_time']
+    self.assertAlmostEqual(st.seconds, int(eta.timestamp()), delta=2)
+
+  def test_get_project_id(self):
+    with mock.patch.dict(os.environ, {cloudtask.ENV_GOOGLE_CLOUD_PROJECT: 's~my-app'}):
+      self.assertEqual(cloudtask._get_project_id(), 'my-app')
+    with mock.patch.dict(os.environ, {cloudtask.ENV_GOOGLE_CLOUD_PROJECT: 'e~my-app'}):
+      self.assertEqual(cloudtask._get_project_id(), 'my-app')
+    with mock.patch.dict(os.environ, {cloudtask.ENV_GOOGLE_CLOUD_PROJECT: 'my-app'}):
+      self.assertEqual(cloudtask._get_project_id(), 'my-app')
+
+  def test_is_cloudtask_push_queue_enabled(self):
+    with mock.patch.dict(os.environ, {cloudtask.ENV_USE_CLOUDTASK_PUSH_QUEUE: 'true'}):
+      self.assertTrue(cloudtask.is_cloudtask_push_queue_enabled())
+    with mock.patch.dict(os.environ, {cloudtask.ENV_USE_CLOUDTASK_PUSH_QUEUE: 'True'}):
+      self.assertTrue(cloudtask.is_cloudtask_push_queue_enabled())
+    with mock.patch.dict(os.environ, {cloudtask.ENV_USE_CLOUDTASK_PUSH_QUEUE: 'false'}):
+      self.assertFalse(cloudtask.is_cloudtask_push_queue_enabled())
+    with mock.patch.dict(os.environ, {}, clear=True):
+      self.assertFalse(cloudtask.is_cloudtask_push_queue_enabled())
+
+  def test_map_rest_code_to_tq_code(self):
+    self.assertEqual(
+        cloudtask._map_rest_code_to_tq_code(code_pb2.NOT_FOUND),
+        taskqueue_service_pb2.TaskQueueServiceError.UNKNOWN_TASK
+    )
+    self.assertEqual(
+        cloudtask._map_rest_code_to_tq_code(http.HTTPStatus.NOT_FOUND),
+        taskqueue_service_pb2.TaskQueueServiceError.UNKNOWN_TASK
+    )
+    self.assertEqual(
+        cloudtask._map_rest_code_to_tq_code(code_pb2.ALREADY_EXISTS),
+        taskqueue_service_pb2.TaskQueueServiceError.TASK_ALREADY_EXISTS
+    )
+    self.assertEqual(
+        cloudtask._map_rest_code_to_tq_code(code_pb2.INVALID_ARGUMENT),
+        taskqueue_service_pb2.TaskQueueServiceError.INVALID_TASK_NAME
+    )
+    self.assertEqual(
+        cloudtask._map_rest_code_to_tq_code(code_pb2.PERMISSION_DENIED),
+        taskqueue_service_pb2.TaskQueueServiceError.PERMISSION_DENIED
+    )
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
### Overview
Adds native Google Cloud Tasks backend routing and Transactional Task support to the App Engine Python Standard TaskQueue SDK (`google.appengine.api.taskqueue`), enabled via the `APPENGINE_USE_CLOUDTASK_PUSH_QUEUE=true` environment variable.

This enables applications using legacy `taskqueue` APIs to seamlessly route push queue traffic through Cloud Tasks (GAPIC `tasks_v2beta3`) without requiring application code refactoring.

---

### Key Features & Changes

1. **Cloud Tasks Push Queue Backend (`cloudtask.py`)**:
   - Routes `Queue.add()`, `Queue.add_async()`, `Task.add()`, `Task.add_async()`, `Queue.delete_tasks()`, `Queue.purge()`, and `Queue.fetch_statistics()` to Cloud Tasks when `is_cloudtask_push_queue_enabled()` is `True` (`APPENGINE_USE_CLOUDTASK_PUSH_QUEUE=true`).
   - Supports both single task creation (`client.create_task`) and bulk task creation (`client.batch_create_tasks`).
   - Translates task retry options (`TaskRetryOptions`), delay/countdown/ETA, HTTP headers, method, and targets into `app_engine_http_request` payloads.
   - Maps Cloud Tasks REST and gRPC status codes (e.g. `ALREADY_EXISTS`, `NOT_FOUND`, `INVALID_ARGUMENT`) into corresponding `taskqueue` exceptions (`TaskAlreadyExistsError`, `UnknownQueueError`, `InvalidTaskError`).
   - Implements `_CloudTaskRPC` with `concurrent.futures.ThreadPoolExecutor` to support asynchronous TaskQueue RPC semantics (`add_async`, `fetch_async`).

2. **Transactional Tasks & Outbox Pattern (`cloudtask_transactional.py`)**:
   - Staged in Datastore (`_AE_PendingCloudTask`) within the active Datastore/NDB transaction to ensure atomic execution.
   - **NDB Integration**: Automatically triggers fast-path dispatch using `ndb.get_context().call_on_commit(...)`.
   - **DB / Datastore Integration**: Added `_on_commit_callbacks` support to `TransactionalConnection` (`datastore_rpc.py`) to execute post-commit callbacks when `db.run_in_transaction()` or `datastore.RunInTransaction()` successfully commits.
   - Handles entity locks, retries, and fast-path grace periods.

3. **Background Sweeper Middleware (`middlewares.py`)**:
   - Added `CloudTaskSweepMiddleware` to intercept cron invocations on `/_ah/cloudtask/sweep` and periodically sweep/retry any pending transactional tasks.

4. **Preserved Pull Queue Compatibility**:
   - Pull queues continue to route through the legacy TaskQueue stub.

---

### Affected Files

| File | Changes |
| :--- | :--- |
| `src/google/appengine/api/taskqueue/cloudtask.py` | Core Cloud Tasks client wrapper, batch creation, error code mapping, and `_CloudTaskRPC` |
| `src/google/appengine/api/taskqueue/cloudtask_transactional.py` | Transactional task staging (`_AE_PendingCloudTask`), post-commit dispatching, and cron sweeper |
| `src/google/appengine/api/taskqueue/taskqueue.py` | Feature flag check `is_cloudtask_push_queue_enabled()` and redirection logic for Queue/Task methods |
| `src/google/appengine/datastore/datastore_rpc.py` | Added `_on_commit_callbacks` execution in `TransactionalConnection.__commit_hook` |
| `src/google/appengine/runtime/middlewares.py` | Added `CloudTaskSweepMiddleware` for `/_ah/cloudtask/sweep` endpoint |
| `tests/google/appengine/api/taskqueue/cloudtask_test.py` | Unit tests for ETA/countdown handling, feature flag helper, and error translation |
| `setup.py` & `src/google/appengine/api/__init__.py` | Dependency and package exports |

---

### Testing & Verification

- **Unit Tests**:
  - Validated ETA POSIX timestamp and countdown conversion to UTC `schedule_time`.
  - Validated gRPC/REST error code mappings.
- **End-to-End App Engine Verification (`dogfood-ec-gajjarc`)**:
  - Single task creation (`/push/api/add`) ✅
  - Batch task creation (`/push/api/add-batch` with 5 tasks) ✅
  - Queue statistics lookup (`/push/stats`) ✅
  - NDB Transactional Tasks (`/tx/ndb`) ✅
  - DB / Datastore Transactional Tasks (`/tx/db`) ✅
  - Sweeper endpoint execution via cron (`/_ah/cloudtask/sweep`) ✅