### PR TITLE
fix(ci): update pypi publish action to release/v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.release.tag_name }}
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
     - name: Install build dependencies
       run: python -m pip install -U setuptools build wheel
     - name: Build distributions
       run: python -m build
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### Overview
Updates `.github/workflows/release.yml` to use `pypa/gh-action-pypi-publish@release/v1` instead of the sunset `@master` branch tag.

### Changes
- Updated `pypa/gh-action-pypi-publish` from `@master` to `@release/v1`.
- Bumped `actions/checkout` to `@v4` and `actions/setup-python` to `@v5`.
- Fixes the PyPI release publishing failure when publishing new release tags.